### PR TITLE
ETag is based on the file's mtime. #performance

### DIFF
--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -39,7 +39,8 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
     function createFile($name, $data = null) {
 
         $newPath = $this->path . '/' . $name;
-        file_put_contents($newPath,$data);
+        file_put_contents($newPath, $data);
+        clearstatcache(true, $newPath);
 
     }
 
@@ -53,6 +54,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
 
         $newPath = $this->path . '/' . $name;
         mkdir($newPath);
+        clearstatcache(true, $newPath);
 
     }
 

--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -70,7 +70,11 @@ class File extends Node implements DAV\IFile {
      */
     function getETag() {
 
-        return '"' . sha1(filemtime($this->path)). '"';
+        return '"' . sha1(
+            fileinode($this->path) .
+            filesize($this->path) .
+            filemtime($this->path)
+        ). '"';
 
     }
 

--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -70,7 +70,7 @@ class File extends Node implements DAV\IFile {
      */
     function getETag() {
 
-        return null;
+        return '"' . sha1(filemtime($this->path)). '"';
 
     }
 

--- a/lib/DAV/FS/File.php
+++ b/lib/DAV/FS/File.php
@@ -22,6 +22,7 @@ class File extends Node implements DAV\IFile {
     function put($data) {
 
         file_put_contents($this->path,$data);
+        clearstatcache(true, $this->path);
 
     }
 

--- a/lib/DAV/FS/Node.php
+++ b/lib/DAV/FS/Node.php
@@ -67,8 +67,6 @@ abstract class Node implements DAV\INode {
 
     }
 
-
-
     /**
      * Returns the last modification time, as a unix timestamp
      *

--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -43,6 +43,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
         if ($name=='.' || $name=='..') throw new DAV\Exception\Forbidden('Permission denied to . and ..');
         $newPath = $this->path . '/' . $name;
         file_put_contents($newPath,$data);
+        clearstatcache(true, $newPath);
 
         return '"' . sha1(
             fileinode($newPath) .
@@ -64,6 +65,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
         if ($name=='.' || $name=='..') throw new DAV\Exception\Forbidden('Permission denied to . and ..');
         $newPath = $this->path . '/' . $name;
         mkdir($newPath);
+        clearstatcache(true, $newPath);
 
     }
 

--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -44,7 +44,11 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
         $newPath = $this->path . '/' . $name;
         file_put_contents($newPath,$data);
 
-        return '"' . md5_file($newPath) . '"';
+        return '"' . sha1(
+            fileinode($newPath) .
+            filesize($newPath) .
+            filemtime($newPath)
+        ). '"';
 
     }
 

--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -125,11 +125,12 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
             \FilesystemIterator::CURRENT_AS_SELF
           | \FilesystemIterator::SKIP_DOTS
         );
+
         foreach($iterator as $entry) {
 
             $node = $entry->getFilename();
 
-            if($node === '.sabredav')
+            if ($node === '.sabredav')
                 continue;
 
             $nodes[] = $this->getChild($node);

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -23,6 +23,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
     function put($data) {
 
         file_put_contents($this->path,$data);
+        clearstatcache(true, $this->path);
         return $this->getETag();
 
     }
@@ -75,6 +76,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
             stream_copy_to_stream($data,$f);
         }
         fclose($f);
+        clearstatcache(true, $this->path);
         return $this->getETag();
 
     }

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -23,7 +23,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
     function put($data) {
 
         file_put_contents($this->path,$data);
-        return '"' . md5_file($this->path) . '"';
+        return $this->getETag();
 
     }
 
@@ -42,7 +42,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
      * The third argument is the start or end byte.
      *
      * After a successful put operation, you may choose to return an ETag. The
-     * etag must always be surrounded by double-quotes. These quotes must
+     * ETAG must always be surrounded by double-quotes. These quotes must
      * appear in the actual string you're returning.
      *
      * Clients may use the ETag from a PUT request to later on make sure that
@@ -75,7 +75,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
             stream_copy_to_stream($data,$f);
         }
         fclose($f);
-        return '"' . md5_file($this->path) . '"';
+        return $this->getETag();
 
     }
 

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -15,7 +15,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
     /**
      * Updates the data
      *
-     * data is a readable stream resource.
+     * Data is a readable stream resource.
      *
      * @param resource|string $data
      * @return string
@@ -112,7 +112,11 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
      */
     function getETag() {
 
-        return '"' . sha1(filemtime($this->path)). '"';
+        return '"' . sha1(
+            fileinode($this->path) .
+            filesize($this->path) .
+            filemtime($this->path)
+        ). '"';
 
     }
 

--- a/lib/DAV/FSExt/File.php
+++ b/lib/DAV/FSExt/File.php
@@ -112,7 +112,7 @@ class File extends Node implements DAV\PartialUpdate\IPatchSupport {
      */
     function getETag() {
 
-        return '"' . md5_file($this->path). '"';
+        return '"' . sha1(filemtime($this->path)). '"';
 
     }
 

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1046,7 +1046,7 @@ class Server extends EventEmitter {
         // body, before it gets written. If this is the case, $modified
         // should be set to true.
         //
-        // If $modified is true, we must not send back an etag.
+        // If $modified is true, we must not send back an ETag.
         $modified = false;
         if (!$this->emit('beforeCreateFile',[$uri, &$data, $parent, &$modified])) return false;
 
@@ -1080,7 +1080,7 @@ class Server extends EventEmitter {
         // body, before it gets written. If this is the case, $modified
         // should be set to true.
         //
-        // If $modified is true, we must not send back an etag.
+        // If $modified is true, we must not send back an ETag.
         $modified = false;
         if (!$this->emit('beforeWriteContent',[$uri, $node, &$data, &$modified])) return false;
 
@@ -1296,7 +1296,7 @@ class Server extends EventEmitter {
             // Only need to check entity tags if they are not *
             if ($ifMatch!=='*') {
 
-                // There can be multiple etags
+                // There can be multiple ETags
                 $ifMatch = explode(',',$ifMatch);
                 $haveMatch = false;
                 foreach($ifMatch as $ifMatchItem) {
@@ -1325,7 +1325,7 @@ class Server extends EventEmitter {
 
         if ($ifNoneMatch = $request->getHeader('If-None-Match')) {
 
-            // The If-None-Match header contains an etag.
+            // The If-None-Match header contains an ETag.
             // Only if the ETag does not match the current ETag, the request will succeed
             // The header can also contain *, in which case the request
             // will only succeed if the entity does not exist at all.
@@ -1342,7 +1342,7 @@ class Server extends EventEmitter {
                 if ($ifNoneMatch==='*') $haveMatch = true;
                 else {
 
-                    // There might be multiple etags
+                    // There might be multiple ETags
                     $ifNoneMatch = explode(',', $ifNoneMatch);
                     $etag = $node->getETag();
 
@@ -1419,7 +1419,7 @@ class Server extends EventEmitter {
         }
 
         // Now the hardest, the If: header. The If: header can contain multiple
-        // urls, etags and so-called 'state tokens'.
+        // urls, ETags and so-called 'state tokens'.
         //
         // Examples of state tokens include lock-tokens (as defined in rfc4918)
         // and sync-tokens (as defined in rfc6578).
@@ -1457,12 +1457,12 @@ class Server extends EventEmitter {
                 if (!$token['etag']) {
                     $etagValid = true;
                 }
-                // Checking the etag, only if the token was already deamed
+                // Checking the ETag, only if the token was already deamed
                 // valid and there is one.
                 if ($token['etag'] && $tokenValid) {
 
-                    // The token was valid, and there was an etag.. We must
-                    // grab the current etag and check it.
+                    // The token was valid, and there was an ETag. We must
+                    // grab the current ETag and check it.
                     $node = $this->tree->getNodeForPath($uri);
                     $etagValid = $node instanceof IFile && $node->getETag() == $token['etag'];
 
@@ -1477,7 +1477,7 @@ class Server extends EventEmitter {
 
             }
 
-            // If we ended here, it means there was no valid etag + token
+            // If we ended here, it means there was no valid ETag + token
             // combination found for the current condition. This means we fail!
             throw new Exception\PreconditionFailed('Failed to find a valid token/etag combination for ' . $uri, 'If');
 

--- a/lib/DAV/SimpleFile.php
+++ b/lib/DAV/SimpleFile.php
@@ -102,7 +102,7 @@ class SimpleFile extends File {
      */
     function getETag() {
 
-        return '"' . md5($this->contents) . '"';
+        return '"' . sha1($this->contents) . '"';
 
     }
 

--- a/tests/Sabre/DAV/FSExt/FileTest.php
+++ b/tests/Sabre/DAV/FSExt/FileTest.php
@@ -74,7 +74,7 @@ class FileTest extends \PHPUnit_Framework_TestCase {
     function testGetETag() {
 
        $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $this->assertEquals('"' . md5('Contents') . '"',$file->getETag());
+       $this->assertEquals('"' . sha1(filemtime(SABRE_TEMPDIR . '/file.txt')) . '"',$file->getETag());
 
     }
 

--- a/tests/Sabre/DAV/FSExt/FileTest.php
+++ b/tests/Sabre/DAV/FSExt/FileTest.php
@@ -22,73 +22,90 @@ class FileTest extends \PHPUnit_Framework_TestCase {
 
     function testPut() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $result = $file->put('New contents');
+        $filename = SABRE_TEMPDIR . '/file.txt';
+        $file = new File($filename);
+        $result = $file->put('New contents');
 
-       $this->assertEquals('New contents',file_get_contents(SABRE_TEMPDIR . '/file.txt'));
-       $this->assertEquals('"' . md5('New contents') . '"', $result);
+        $this->assertEquals('New contents',file_get_contents(SABRE_TEMPDIR . '/file.txt'));
+        $this->assertEquals(
+            '"' .
+            sha1(
+                fileinode($filename) .
+                filesize($filename ) .
+                filemtime($filename)
+            ) . '"',
+            $result
+        );
 
     }
 
     function testRange() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $file->put('0000000');
-       $file->patch('111', 2, 3);
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $file->put('0000000');
+        $file->patch('111', 2, 3);
 
-       $this->assertEquals('0001110',file_get_contents(SABRE_TEMPDIR . '/file.txt'));
+        $this->assertEquals('0001110',file_get_contents(SABRE_TEMPDIR . '/file.txt'));
 
     }
 
     function testRangeStream() {
 
-       $stream = fopen('php://memory','r+');
-       fwrite($stream, "222");
-       rewind($stream);
+        $stream = fopen('php://memory','r+');
+        fwrite($stream, "222");
+        rewind($stream);
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $file->put('0000000');
-       $file->patch($stream, 2, 3);
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $file->put('0000000');
+        $file->patch($stream, 2, 3);
 
-       $this->assertEquals('0002220',file_get_contents(SABRE_TEMPDIR . '/file.txt'));
+        $this->assertEquals('0002220',file_get_contents(SABRE_TEMPDIR . '/file.txt'));
 
     }
 
 
     function testGet() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $this->assertEquals('Contents',stream_get_contents($file->get()));
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $this->assertEquals('Contents',stream_get_contents($file->get()));
 
     }
 
     function testDelete() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $file->delete();
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $file->delete();
 
-       $this->assertFalse(file_exists(SABRE_TEMPDIR . '/file.txt'));
+        $this->assertFalse(file_exists(SABRE_TEMPDIR . '/file.txt'));
 
     }
 
     function testGetETag() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $this->assertEquals('"' . sha1(filemtime(SABRE_TEMPDIR . '/file.txt')) . '"',$file->getETag());
-
+        $filename = SABRE_TEMPDIR . '/file.txt';
+        $file = new File($filename);
+        $this->assertEquals(
+            '"' .
+            sha1(
+                fileinode($filename) .
+                filesize($filename ) .
+                filemtime($filename)
+            ) . '"',
+            $file->getETag()
+        );
     }
 
     function testGetContentType() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $this->assertNull($file->getContentType());
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $this->assertNull($file->getContentType());
 
     }
 
     function testGetSize() {
 
-       $file = new File(SABRE_TEMPDIR . '/file.txt');
-       $this->assertEquals(8,$file->getSize());
+        $file = new File(SABRE_TEMPDIR . '/file.txt');
+        $this->assertEquals(8,$file->getSize());
 
     }
 

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -18,6 +18,7 @@ class ServerTest extends DAV\AbstractServer{
     function testGet() {
 
         $request = new HTTP\Request('GET', '/test.txt');
+        $filename = $this->tempDir . '/test.txt';
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -26,8 +27,8 @@ class ServerTest extends DAV\AbstractServer{
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
-            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'            => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($filename)))],
+            'ETag'            => ['"' . sha1(fileinode($filename ) . filesize($filename) . filemtime($filename)) . '"'],
             ],
             $this->response->getHeaders()
          );
@@ -40,6 +41,7 @@ class ServerTest extends DAV\AbstractServer{
     function testHEAD() {
 
         $request = new HTTP\Request('HEAD', '/test.txt');
+        $filename = $this->tempDir . '/test.txt';
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
@@ -48,7 +50,7 @@ class ServerTest extends DAV\AbstractServer{
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'            => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
+            'ETag'            => ['"' . sha1(fileinode($filename ) . filesize($filename) . filemtime($filename)) . '"'],
             ],
             $this->response->getHeaders()
          );
@@ -61,19 +63,20 @@ class ServerTest extends DAV\AbstractServer{
     function testPut() {
 
         $request = new HTTP\Request('PUT', '/testput.txt');
+        $filename = $this->tempDir . '/testput.txt';
         $request->setBody('Testing new file');
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
         $this->assertEquals([
             'X-Sabre-Version' => [DAV\Version::VERSION],
-            'Content-Length' => [0],
-            'ETag'           => ['"' . md5('Testing new file') . '"'],
+            'Content-Length'  => [0],
+            'ETag'            => ['"' . sha1(fileinode($filename ) . filesize($filename) . filemtime($filename)) . '"'],
         ], $this->response->getHeaders());
 
         $this->assertEquals(201, $this->response->status);
         $this->assertEquals('', $this->response->body);
-        $this->assertEquals('Testing new file',file_get_contents($this->tempDir . '/testput.txt'));
+        $this->assertEquals('Testing new file',file_get_contents($filename));
 
     }
 
@@ -220,9 +223,8 @@ class ServerTest extends DAV\AbstractServer{
         $tree = new DAV\Tree(new DAV\SimpleCollection('root', [
             new DAV\FS\Directory($this->tempDir . '/tree1'),
             new DAV\FSExt\Directory($this->tempDir . '/tree2'),
-            ]));
+        ]));
         $this->server->tree = $tree;
-
 
         $request = new HTTP\Request('MOVE', '/tree1', ['Destination' => '/tree2/tree1']);
         $this->server->httpRequest = ($request);

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -27,7 +27,7 @@ class ServerTest extends DAV\AbstractServer{
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'            => ['"'  .md5_file($this->tempDir . '/test.txt') . '"'],
+            'ETag'            => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ],
             $this->response->getHeaders()
          );
@@ -48,7 +48,7 @@ class ServerTest extends DAV\AbstractServer{
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
             'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'            => ['"' . md5_file($this->tempDir . '/test.txt') . '"'],
+            'ETag'            => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ],
             $this->response->getHeaders()
          );

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -902,7 +902,7 @@ class PluginTest extends DAV\AbstractServer {
         $tree = new DAV\Tree(new DAV\FSExt\Directory(SABRE_TEMPDIR));
         $this->server->tree = $tree;
 
-        $etag = md5(file_get_contents(SABRE_TEMPDIR . '/test.txt'));
+        $etag = sha1(filemtime(SABRE_TEMPDIR . '/test.txt'));
         $serverVars = array(
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'PUT',

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -898,11 +898,16 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testPutWithCorrectETag() {
 
-        // We need an etag-enabled file node.
+        // We need an ETag-enabled file node.
         $tree = new DAV\Tree(new DAV\FSExt\Directory(SABRE_TEMPDIR));
         $this->server->tree = $tree;
 
-        $etag = sha1(filemtime(SABRE_TEMPDIR . '/test.txt'));
+        $filename = SABRE_TEMPDIR . '/test.txt';
+        $etag = sha1(
+            fileinode($filename) .
+            filesize($filename ) .
+            filemtime($filename)
+        );
         $serverVars = array(
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'PUT',

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -31,7 +31,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Length' => [4],
             'Content-Range' => ['bytes 2-5/13'],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')). '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -62,7 +62,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Length' => [11],
             'Content-Range' => ['bytes 2-12/13'],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')) . '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -93,7 +93,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Length' => [8],
             'Content-Range' => ['bytes 5-12/13'],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')). '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')). '"'],
             ),
             $this->response->getHeaders()
          );
@@ -165,7 +165,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Length' => [4],
             'Content-Range' => ['bytes 2-5/13'],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')) . '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -198,7 +198,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')) . '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -232,7 +232,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Length' => [4],
             'Content-Range' => ['bytes 2-5/13'],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')) . '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -265,7 +265,7 @@ class ServerRangeTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . md5(file_get_contents(SABRE_TEMPDIR . '/test.txt')) . '"'],
+            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -15,24 +15,25 @@ class ServerRangeTest extends AbstractServer{
 
     function testRange() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=2-5',
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [4],
-            'Content-Range' => ['bytes 2-5/13'],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [4],
+            'Content-Range'   => ['bytes 2-5/13'],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -46,24 +47,25 @@ class ServerRangeTest extends AbstractServer{
      */
     function testStartRange() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=2-',
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [11],
-            'Content-Range' => ['bytes 2-12/13'],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [11],
+            'Content-Range'   => ['bytes 2-12/13'],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -77,24 +79,25 @@ class ServerRangeTest extends AbstractServer{
      */
     function testEndRange() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=-8',
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [8],
-            'Content-Range' => ['bytes 5-12/13'],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')). '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [8],
+            'Content-Range'   => ['bytes 5-12/13'],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -108,11 +111,11 @@ class ServerRangeTest extends AbstractServer{
      */
     function testTooHighRange() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=100-200',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
@@ -127,11 +130,11 @@ class ServerRangeTest extends AbstractServer{
      */
     function testCrazyRange() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=8-4',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
@@ -148,25 +151,26 @@ class ServerRangeTest extends AbstractServer{
 
         $node = $this->server->tree->getNodeForPath('test.txt');
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=2-5',
             'HTTP_IF_RANGE'  => $node->getETag(),
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [4],
-            'Content-Range' => ['bytes 2-5/13'],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [4],
+            'Content-Range'   => ['bytes 2-5/13'],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -182,24 +186,25 @@ class ServerRangeTest extends AbstractServer{
 
         $node = $this->server->tree->getNodeForPath('test.txt');
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=2-5',
             'HTTP_IF_RANGE'  => $node->getETag() . 'blabla',
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -215,25 +220,26 @@ class ServerRangeTest extends AbstractServer{
 
         $node = $this->server->tree->getNodeForPath('test.txt');
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=2-5',
             'HTTP_IF_RANGE'  => 'tomorrow',
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [4],
-            'Content-Range' => ['bytes 2-5/13'],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [4],
+            'Content-Range'   => ['bytes 2-5/13'],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -249,24 +255,25 @@ class ServerRangeTest extends AbstractServer{
 
         $node = $this->server->tree->getNodeForPath('test.txt');
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
             'HTTP_RANGE'     => 'bytes=2-5',
             'HTTP_IF_RANGE'  => '-2 years',
-        );
+        ];
+        $filename = SABRE_TEMPDIR . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag'          => ['"' . sha1(filemtime(SABRE_TEMPDIR . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -8,9 +8,9 @@ class ServerSimpleTest extends AbstractServer{
 
     function testConstructArray() {
 
-        $nodes = array(
+        $nodes = [
             new SimpleCollection('hello')
-        );
+        ];
 
         $server = new Server($nodes);
         $this->assertEquals($nodes[0], $server->tree->getNodeForPath('hello'));
@@ -22,10 +22,10 @@ class ServerSimpleTest extends AbstractServer{
      */
     function testConstructIncorrectObj() {
 
-        $nodes = array(
+        $nodes = [
             new SimpleCollection('hello'),
             new \STDClass(),
-        );
+        ];
 
         $server = new Server($nodes);
 
@@ -42,22 +42,23 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGet() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'GET',
-        );
+        ];
+        $filename = $this->tempDir . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -65,25 +66,27 @@ class ServerSimpleTest extends AbstractServer{
         $this->assertEquals('Test contents', stream_get_contents($this->response->body));
 
     }
+
     function testGetHttp10() {
 
-        $serverVars = array(
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'GET',
+        $serverVars = [
+            'REQUEST_URI'     => '/test.txt',
+            'REQUEST_METHOD'  => 'GET',
             'SERVER_PROTOCOL' => 'HTTP/1.0',
-        );
+        ];
+        $filename = $this->tempDir . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -95,10 +98,10 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGetDoesntExist() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt_randomblbla',
             'REQUEST_METHOD' => 'GET',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
@@ -109,10 +112,10 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGetDoesntExist2() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt/randomblbla',
             'REQUEST_METHOD' => 'GET',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
@@ -129,22 +132,23 @@ class ServerSimpleTest extends AbstractServer{
      */
     function testGetDoubleSlash() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '//test.txt',
             'REQUEST_METHOD' => 'GET',
-        );
+        ];
+        $filename = $this->tempDir . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -156,22 +160,23 @@ class ServerSimpleTest extends AbstractServer{
 
     function testHEAD() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/test.txt',
             'REQUEST_METHOD' => 'HEAD',
-        );
+        ];
+        $filename = $this->tempDir . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' .  filemtime($this->tempDir . '/test.txt')))],
-            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' .  filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -186,14 +191,14 @@ class ServerSimpleTest extends AbstractServer{
         $this->server->httpRequest = $request;
         $this->server->exec();
 
-        $this->assertEquals(array(
-            'DAV'            => ['1, 3, extended-mkcol'],
-            'MS-Author-Via'  => ['DAV'],
-            'Allow'          => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
-            'Accept-Ranges'  => ['bytes'],
-            'Content-Length' => ['0'],
+        $this->assertEquals([
+            'DAV'             => ['1, 3, extended-mkcol'],
+            'MS-Author-Via'   => ['DAV'],
+            'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT'],
+            'Accept-Ranges'   => ['bytes'],
+            'Content-Length'  => ['0'],
             'X-Sabre-Version' => [Version::VERSION],
-        ),$this->response->getHeaders());
+        ],$this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
         $this->assertEquals('', $this->response->body);
@@ -207,14 +212,14 @@ class ServerSimpleTest extends AbstractServer{
 
         $this->server->exec();
 
-        $this->assertEquals(array(
-            'DAV'            => ['1, 3, extended-mkcol'],
-            'MS-Author-Via'  => ['DAV'],
-            'Allow'          => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT, MKCOL'],
-            'Accept-Ranges'  => ['bytes'],
-            'Content-Length' => ['0'],
+        $this->assertEquals([
+            'DAV'             => ['1, 3, extended-mkcol'],
+            'MS-Author-Via'   => ['DAV'],
+            'Allow'           => ['OPTIONS, GET, HEAD, DELETE, PROPFIND, PUT, PROPPATCH, COPY, MOVE, REPORT, MKCOL'],
+            'Accept-Ranges'   => ['bytes'],
+            'Content-Length'  => ['0'],
             'X-Sabre-Version' => [Version::VERSION],
-        ),$this->response->getHeaders());
+        ],$this->response->getHeaders());
 
         $this->assertEquals(200, $this->response->status);
         $this->assertEquals('', $this->response->body);
@@ -223,19 +228,19 @@ class ServerSimpleTest extends AbstractServer{
 
     function testNonExistantMethod() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/',
             'REQUEST_METHOD' => 'BLABLA',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/xml; charset=utf-8'],
-        ),$this->response->getHeaders());
+            'Content-Type'    => ['application/xml; charset=utf-8'],
+        ],$this->response->getHeaders());
 
         $this->assertEquals(501, $this->response->status);
 
@@ -244,19 +249,19 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGETOnCollection() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/',
             'REQUEST_METHOD' => 'GET',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/xml; charset=utf-8'],
-        ),$this->response->getHeaders());
+            'Content-Type'    => ['application/xml; charset=utf-8'],
+        ],$this->response->getHeaders());
 
         $this->assertEquals(501, $this->response->status);
 
@@ -274,10 +279,11 @@ class ServerSimpleTest extends AbstractServer{
 
     function testBaseUri() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/blabla/test.txt',
             'REQUEST_METHOD' => 'GET',
-        );
+        ];
+        $filename = $this->tempDir . '/test.txt';
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->setBaseUri('/blabla/');
@@ -285,13 +291,13 @@ class ServerSimpleTest extends AbstractServer{
         $this->server->httpRequest = ($request);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/octet-stream'],
-            'Content-Length' => [13],
-            'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
-            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
-            ),
+            'Content-Type'    => ['application/octet-stream'],
+            'Content-Length'  => [13],
+            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -302,13 +308,13 @@ class ServerSimpleTest extends AbstractServer{
 
     function testBaseUriAddSlash() {
 
-        $tests = array(
+        $tests = [
             '/'         => '/',
             '/foo'      => '/foo/',
             '/foo/'     => '/foo/',
             '/foo/bar'  => '/foo/bar/',
             '/foo/bar/' => '/foo/bar/',
-        );
+        ];
 
         foreach($tests as $test=>$result) {
             $this->server->setBaseUri($test);
@@ -321,11 +327,11 @@ class ServerSimpleTest extends AbstractServer{
 
     function testCalculateUri() {
 
-        $uris = array(
+        $uris = [
             'http://www.example.org/root/somepath',
             '/root/somepath',
             '/root/somepath/',
-        );
+        ];
 
         $this->server->setBaseUri('/root/');
 
@@ -349,11 +355,11 @@ class ServerSimpleTest extends AbstractServer{
 
     function testCalculateUriSpecialChars() {
 
-        $uris = array(
+        $uris = [
             'http://www.example.org/root/%C3%A0fo%C3%B3',
             '/root/%C3%A0fo%C3%B3',
             '/root/%C3%A0fo%C3%B3/'
-        );
+        ];
 
         $this->server->setBaseUri('/root/');
 
@@ -382,13 +388,29 @@ class ServerSimpleTest extends AbstractServer{
     }
 
     /**
+     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
+    function testBaseUriCheck() {
+
+        $uris = [
+            'http://www.example.org/root/somepath',
+            '/root/somepath',
+            '/root/somepath/'
+        ];
+
+        $this->server->setBaseUri('root/');
+        $this->server->calculateUri('/root/testuri');
+
+        $this->fail('Expected an exception');
+
+    }
+
     function testGuessBaseUri() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/index.php/root',
             'PATH_INFO'   => '/root',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -403,10 +425,10 @@ class ServerSimpleTest extends AbstractServer{
      */
     function testGuessBaseUriPercentEncoding() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/index.php/dir/path2/path%20with%20spaces',
             'PATH_INFO'   => '/dir/path2/path with spaces',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -423,10 +445,10 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriPercentEncoding2() {
 
         $this->markTestIncomplete('This behaviour is not yet implemented');
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/some%20directory+mixed/index.php/dir/path2/path%20with%20spaces',
             'PATH_INFO'   => '/dir/path2/path with spaces',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -438,10 +460,10 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGuessBaseUri2() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/index.php/root/',
             'PATH_INFO'   => '/root/',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -453,9 +475,9 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGuessBaseUriNoPathInfo() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/index.php/root',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -467,9 +489,9 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGuessBaseUriNoPathInfo2() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/a/b/c/test.php',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -485,10 +507,10 @@ class ServerSimpleTest extends AbstractServer{
      */
     function testGuessBaseUriQueryString() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/index.php/root?query_string=blabla',
             'PATH_INFO'   => '/root',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -504,10 +526,10 @@ class ServerSimpleTest extends AbstractServer{
      */
     function testGuessBaseUriBadConfig() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/index.php/root/heyyy',
             'PATH_INFO'   => '/root',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $server = new Server();
@@ -519,19 +541,19 @@ class ServerSimpleTest extends AbstractServer{
 
     function testTriggerException() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI' => '/',
             'REQUEST_METHOD' => 'FOO',
-        );
+        ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = $httpRequest;
         $this->server->on('beforeMethod', [$this,'exceptionTrigger']);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'Content-Type' => ['application/xml; charset=utf-8'],
-        ),$this->response->getHeaders());
+        ],$this->response->getHeaders());
 
         $this->assertEquals(500, $this->response->status);
 
@@ -545,20 +567,20 @@ class ServerSimpleTest extends AbstractServer{
 
     function testReportNotFound() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/',
             'REQUEST_METHOD' => 'REPORT',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
         $this->server->httpRequest->setBody('<?xml version="1.0"?><bla:myreport xmlns:bla="http://www.rooftopsolutions.nl/NS"></bla:myreport>');
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'Content-Type' => ['application/xml; charset=utf-8'],
-            ),
+            'Content-Type'    => ['application/xml; charset=utf-8'],
+            ],
             $this->response->getHeaders()
          );
 
@@ -568,10 +590,10 @@ class ServerSimpleTest extends AbstractServer{
 
     function testReportIntercepted() {
 
-        $serverVars = array(
+        $serverVars = [
             'REQUEST_URI'    => '/',
             'REQUEST_METHOD' => 'REPORT',
-        );
+        ];
 
         $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = ($request);
@@ -579,10 +601,10 @@ class ServerSimpleTest extends AbstractServer{
         $this->server->on('report', [$this,'reportHandler']);
         $this->server->exec();
 
-        $this->assertEquals(array(
+        $this->assertEquals([
             'X-Sabre-Version' => [Version::VERSION],
-            'testheader' => ['testvalue'],
-            ),
+            'testheader'      => ['testvalue'],
+            ],
             $this->response->getHeaders()
         );
 
@@ -603,14 +625,14 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGetPropertiesForChildren() {
 
-        $result = $this->server->getPropertiesForChildren('',array(
+        $result = $this->server->getPropertiesForChildren('',[
             '{DAV:}getcontentlength',
-        ));
+        ]);
 
-        $expected = array(
-            'test.txt' => array('{DAV:}getcontentlength' => 13),
-            'dir/' => array(),
-        );
+        $expected = [
+            'test.txt' => ['{DAV:}getcontentlength' => 13],
+            'dir/'     => [],
+        ];
 
         $this->assertEquals($expected,$result);
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -388,23 +388,7 @@ class ServerSimpleTest extends AbstractServer{
     }
 
     /**
-     * @expectedException \Sabre\DAV\Exception\Forbidden
      */
-    function testBaseUriCheck() {
-
-        $uris = [
-            'http://www.example.org/root/somepath',
-            '/root/somepath',
-            '/root/somepath/'
-        ];
-
-        $this->server->setBaseUri('root/');
-        $this->server->calculateUri('/root/testuri');
-
-        $this->fail('Expected an exception');
-
-    }
-
     function testGuessBaseUri() {
 
         $serverVars = [

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -56,6 +56,7 @@ class ServerSimpleTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -81,6 +82,7 @@ class ServerSimpleTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -141,6 +143,7 @@ class ServerSimpleTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -167,6 +170,7 @@ class ServerSimpleTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' .  filemtime($this->tempDir . '/test.txt')))],
+            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );
@@ -286,6 +290,7 @@ class ServerSimpleTest extends AbstractServer{
             'Content-Type' => ['application/octet-stream'],
             'Content-Length' => [13],
             'Last-Modified' => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'ETag' => ['"' . sha1(filemtime($this->tempDir . '/test.txt')) . '"'],
             ),
             $this->response->getHeaders()
          );

--- a/tests/Sabre/DAV/SimpleFileTest.php
+++ b/tests/Sabre/DAV/SimpleFileTest.php
@@ -11,7 +11,7 @@ class SimpleFileTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals('filename.txt', $file->getName());
         $this->assertEquals('contents', $file->get());
         $this->assertEquals('8', $file->getSize());
-        $this->assertEquals('"' . md5('contents') . '"', $file->getETag());
+        $this->assertEquals('"' . sha1('contents') . '"', $file->getETag());
         $this->assertEquals('text/plain', $file->getContentType());
 
     }


### PR DESCRIPTION
Quoting the documentation of the `DAV\IFile::getETag` method:

> An ETag is a unique identifier representing the current version of the file. If the file changes, the ETag MUST change.

In [`DAV\FSExt\File`](https://github.com/fruux/sabre-dav/blob/93e61954fd82dfc397055cec5a10a636cf982a45/lib/DAV/FSExt/File.php#L115), we use the [`md5_file` function (documentation)](http://php.net/md5_file). I was thinking: I wonder if it can cause performance issue? I think yes because the [`md5_file` function (implementation)](http://lxr.php.net/xref/PHP_5_6/ext/hash/hash_md.c#135) reads the entire file in order to compute the MD5 hash. So with a file of 5Gb, it can hurt. I was then thinking: why not having a better way to compute the Etag of a file? Well, the [`mtime`](http://php.net/filemtime)! In order to protect the data behind the Etag, we encode this data with a SHA1.

However, I have also noticed that `FS\File` returns a `null` Etag while we can apply the same approach. So this PR fixes these two guys + respective tests.

Finally, a last patch ensures that the `fstat`'s cache is clear before computing the `ETag`. We optimize this cache invalidation by clearing only the cache of the current file, not for all the FS.