### PR TITLE
Introduce the FSIterator.

### DIFF
--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -85,24 +85,13 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
     }
 
     /**
-     * Returns an array with all the child nodes
+     * Returns an iterator with all the child nodes
      *
-     * @return DAV\INode[]
+     * @return DAV\FSIterator
      */
     function getChildren() {
 
-        $nodes = [];
-        $iterator = new \FilesystemIterator(
-            $this->path,
-            \FilesystemIterator::CURRENT_AS_SELF
-          | \FilesystemIterator::SKIP_DOTS
-        );
-        foreach($iterator as $entry) {
-
-            $nodes[] = $this->getChild($entry->getFilename());
-
-        }
-        return $nodes;
+        return new DAV\FSIterator($this, $this->path);
 
     }
 
@@ -146,4 +135,3 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
     }
 
 }
-

--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -109,29 +109,20 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
     }
 
     /**
-     * Returns an array with all the child nodes
+     * Returns an iterator with all the child nodes
      *
-     * @return DAV\INode[]
+     * @return DAV\FSIterator
      */
     function getChildren() {
 
-        $nodes = [];
-        $iterator = new \FilesystemIterator(
+        return new DAV\FSIterator(
+            $this,
             $this->path,
-            \FilesystemIterator::CURRENT_AS_SELF
-          | \FilesystemIterator::SKIP_DOTS
+            function ( $current ) {
+
+                return '.sabredav' !== $current->getFilename();
+            }
         );
-        foreach($iterator as $entry) {
-
-            $node = $entry->getFilename();
-
-            if($node === '.sabredav')
-                continue;
-
-            $nodes[] = $this->getChild($node);
-
-        }
-        return $nodes;
 
     }
 

--- a/lib/DAV/FSIterator.php
+++ b/lib/DAV/FSIterator.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Sabre\DAV;
+
+use CallbackFilterIterator;
+use FilesystemIterator;
+
+/**
+ * FS iterator.
+ *
+ * Transform any children of a directory into a collection of nodes.
+ *
+ * @copyright Copyright (C) 2007-2014 fruux GmbH (https://fruux.com/).
+ * @author Ivan Enderlin
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class FSIterator extends CallbackFilterIterator {
+
+    /**
+     * Collection to iterate.
+     *
+     * @var ICollection
+     */
+    protected $collection;
+
+    /**
+     * Constructor.
+     *
+     * Based on a collection and a path, we build an iterator that transforms
+     * every children of the path in the collection into a node. A filter can be
+     * added and receive a \FilesystemIterator object as the only argument, i.e.
+     * the child is not yet a node.
+     *
+     * @param ICollection $collection
+     * @param string $path
+     * @param callable|null $filter
+     */
+    public function __construct(ICollection $collection, $path, callable $filter = null) {
+
+        $this->setCollection($collection);
+
+        if (is_null($filter)) {
+            $filter = function ( ) { return true; };
+        }
+
+        parent::__construct(
+            new FilesystemIterator(
+                $path,
+                FilesystemIterator::CURRENT_AS_SELF | FilesystemIterator::SKIP_DOTS
+            ),
+            $filter
+        );
+
+    }
+
+    /**
+     * Get the current element as a node.
+     *
+     * @return INode
+     */
+    public function current() {
+
+        return $this->getCollection()->getChild(
+            parent::current()->getFilename()
+        );
+
+    }
+
+    /**
+     * Set the collection handler.
+     *
+     * @param ICollection $collection
+     */
+    protected function setCollection(ICollection $collection) {
+
+        $this->collection = $collection;
+
+    }
+
+    /**
+     * Get the collection handler.
+     *
+     * @return ICollection
+     */
+    public function getCollection() {
+
+        return $this->collection;
+
+    }
+
+}

--- a/lib/DAV/FSIterator.php
+++ b/lib/DAV/FSIterator.php
@@ -40,7 +40,9 @@ class FSIterator extends CallbackFilterIterator {
         $this->setCollection($collection);
 
         if (is_null($filter)) {
-            $filter = function ( ) { return true; };
+            $filter = function ( ) {
+                return true;
+            };
         }
 
         parent::__construct(

--- a/lib/DAV/FSIterator.php
+++ b/lib/DAV/FSIterator.php
@@ -68,6 +68,11 @@ class FSIterator extends CallbackFilterIterator {
 
     }
 
+    public function accept() {
+
+        return parent::accept();
+    }
+
     /**
      * Set the collection handler.
      *


### PR DESCRIPTION
First step consisted to remove `scandir` and replace it by `FilesystemIterator` (see 8c81bc3). However, while it is a little bit faster and cross-FS, it does not solve the problem of memory consumption (and inherited CPU consumption) when having a lot of children.

Thus, this second step consists to solve this bottleneck. Instead of:

  1. iterating 1 time on children,
  2. transform them into nodes and
  3. return all the nodes as an array, which will be iterated a 2nd time,

we build an iterator that:

  1. given a collection (`ICollection`) and a path,
  2. generate and return a filesystem iterator that transforms children into nodes on demand.

Children are iterated later.

Bonus: a filter can be added, useful in `FSExt/Directory.php` for instance.