### PR TITLE
Handle floatingTimes in ICSExportPlugin

### DIFF
--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -3,6 +3,7 @@
 namespace Sabre\CalDAV;
 
 use
+    DateTimeZone,
     Sabre\DAV,
     Sabre\VObject,
     Sabre\HTTP\RequestInterface,
@@ -211,7 +212,23 @@ class ICSExportPlugin extends DAV\ServerPlugin {
         );
 
         if ($expand) {
-            $mergedCalendar->expand($start, $end);
+            $calendarTimeZone = null;
+            // We're expanding, and for that we need to figure out the
+            // calendar's timezone.
+            $tzProp = '{' . Plugin::NS_CALDAV . '}calendar-timezone';
+            $tzResult = $this->server->getProperties($path, [$tzProp]);
+            if (isset($tzResult[$tzProp])) {
+                // This property contains a VCALENDAR with a single
+                // VTIMEZONE.
+                $vtimezoneObj = VObject\Reader::read($tzResult[$tzProp]);
+                $calendarTimeZone = $vtimezoneObj->VTIMEZONE->getTimeZone();
+                unset($vtimezoneObj);
+            } else {
+                // Defaulting to UTC.
+                $calendarTimeZone = new DateTimeZone('UTC');
+            }
+
+            $mergedCalendar->expand($start, $end, $calendarTimeZone);
         }
 
         $response->setHeader('Content-Type', $format);

--- a/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
@@ -12,6 +12,8 @@ class ExpandEventsFloatingTimeTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
 
+    protected $setupCalDAVICSExport = true;
+
     protected $caldavCalendars = array(
         array(
             'id' => 1,
@@ -138,6 +140,44 @@ END:VCALENDAR
         $response = $this->request($request);
 
         $this->assertEquals(207, $response->getStatus());
+
+        // Everts super awesome xml parser.
+        $body = substr(
+            $response->body,
+            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
+            strpos($response->body, 'END:VCALENDAR') - $start + 13
+        );
+        $body = str_replace('&#13;','',$body);
+
+        $vObject = VObject\Reader::read($body);
+
+        // check if DTSTARTs and DTENDs are correct
+        foreach ($vObject->VEVENT as $vevent) {
+            /** @var $vevent Sabre\VObject\Component\VEvent */
+            foreach ($vevent->children as $child) {
+                /** @var $child Sabre\VObject\Property */
+
+                if ($child->name == 'DTSTART') {
+                    // DTSTART should be the UTC equivalent of given floating time
+                    $this->assertEquals($child->getValue(), '20141108T043000Z');
+                } elseif ($child->name == 'DTEND') {
+                    // DTEND should be the UTC equivalent of given floating time
+                    $this->assertEquals($child->getValue(), '20141108T063000Z');
+                }
+            }
+        }
+    }
+
+    function testExpandExport() {
+
+        $request = new HTTP\Request('GET', '/calendars/user1/calendar1?export&start=1&end=2000000000&expand=1', [
+            'Depth' => 1,
+            'Content-Type' => 'application/xml',
+        ]);
+
+        $response = $this->request($request);
+
+        $this->assertEquals(200, $response->getStatus());
 
         // Everts super awesome xml parser.
         $body = substr(

--- a/tests/Sabre/DAVServerTest.php
+++ b/tests/Sabre/DAVServerTest.php
@@ -25,6 +25,7 @@ abstract class DAVServerTest extends \PHPUnit_Framework_TestCase {
     protected $setupCalDAVSharing = false;
     protected $setupCalDAVScheduling = false;
     protected $setupCalDAVSubscriptions = false;
+    protected $setupCalDAVICSExport = false;
     protected $setupLocks = false;
     protected $setupFiles = false;
 
@@ -116,6 +117,10 @@ abstract class DAVServerTest extends \PHPUnit_Framework_TestCase {
         }
         if ($this->setupCalDAVSubscriptions) {
             $this->server->addPlugin(new CalDAV\Subscriptions\Plugin());
+        }
+        if ($this->setupCalDAVICSExport) {
+            $this->caldavICSExportPlugin = new CalDAV\ICSExportPlugin();
+            $this->server->addPlugin($this->caldavICSExportPlugin);
         }
         if ($this->setupCardDAV) {
             $this->carddavPlugin = new CardDAV\Plugin();


### PR DESCRIPTION
A calendars timezone is already considered for events with floating times in e.g. FreeBusy requests (see #555) but not when expanding events in the ICSExportPlugin. This Pull Request adds that.