### PR TITLE
Issue #581 : Fixed blank principalPrefix in findByUri

### DIFF
--- a/lib/DAVACL/AbstractPrincipalCollection.php
+++ b/lib/DAVACL/AbstractPrincipalCollection.php
@@ -174,7 +174,7 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
      */
     function findByUri($uri) {
 
-        return $this->principalBackend->findByUri($uri);
+        return $this->principalBackend->findByUri($uri, $this->principalPrefix);
 
     }
 

--- a/lib/DAVACL/PrincipalBackend/AbstractBackend.php
+++ b/lib/DAVACL/PrincipalBackend/AbstractBackend.php
@@ -29,9 +29,10 @@ abstract class AbstractBackend implements BackendInterface {
      * principal was not found or you refuse to find it.
      *
      * @param string $uri
+     * @param string $principalPrefix
      * @return string
      */
-    function findByUri($uri) {
+    function findByUri($uri, $principalPrefix) {
 
         // Note that the default implementation here is a bit slow and could
         // likely be optimized.
@@ -39,7 +40,7 @@ abstract class AbstractBackend implements BackendInterface {
             return;
         }
         $result = $this->searchPrincipals(
-            '',
+            $principalPrefix,
             ['{http://sabredav.org/ns}email-address' => substr($uri,7)]
         );
 

--- a/lib/DAVACL/PrincipalBackend/BackendInterface.php
+++ b/lib/DAVACL/PrincipalBackend/BackendInterface.php
@@ -106,9 +106,10 @@ interface BackendInterface {
      * principal was not found or you refuse to find it.
      *
      * @param string $uri
+     * @param string $principalPrefix
      * @return string
      */
-    function findByUri($uri);
+    function findByUri($uri, $principalPrefix);
 
     /**
      * Returns the list of members for a group-principal

--- a/tests/Sabre/DAVACL/PrincipalCollectionTest.php
+++ b/tests/Sabre/DAVACL/PrincipalCollectionTest.php
@@ -49,4 +49,13 @@ class PrincipalCollectionTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    public function testFindByUri() {
+
+        $backend = new PrincipalBackend\Mock();
+        $pc = new PrincipalCollection($backend);
+        $this->assertEquals('principals/user1', $pc->findByUri('mailto:user1.sabredav@sabredav.org'));
+        $this->assertNull($pc->findByUri('mailto:fake.user.sabredav@sabredav.org'));
+        $this->assertNull($pc->findByUri(''));
+    }
+
 }


### PR DESCRIPTION
The principalPrefix sent to searchPrincipals was set to a literal blank
string and would never return a valid result unless no prefix was used.

https://github.com/fruux/sabre-dav/issues/581