### PR TITLE
Prevent enumeration of absolute path using Browser Plugin

### DIFF
--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -456,6 +456,7 @@ HTML;
      *
      * @param string $assetName
      * @return string
+     * @throws DAV\Exception\NotFound
      */
     protected function getLocalAssetPath($assetName) {
 
@@ -463,6 +464,10 @@ HTML;
         $path = $assetDir . $assetName;
 
         // Making sure people aren't trying to escape from the base path.
+        $path = str_replace('\\', '/', $path);
+        if (strpos($path, '/../') !== FALSE || strrchr($path, '/') === '/..') {
+            throw new DAV\Exception\NotFound('Path does not exist, or escaping from the base path was detected');
+        }
         if (strpos(realpath($path), realpath($assetDir)) === 0 && file_exists($path)) {
             return $path;
         }

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -465,7 +465,7 @@ HTML;
 
         // Making sure people aren't trying to escape from the base path.
         $path = str_replace('\\', '/', $path);
-        if (strpos($path, '/../') !== FALSE || strrchr($path, '/') === '/..') {
+        if (strpos($path, '/../') !== false || strrchr($path, '/') === '/..') {
             throw new DAV\Exception\NotFound('Path does not exist, or escaping from the base path was detected');
         }
         if (strpos(realpath($path), realpath($assetDir)) === 0 && file_exists($path)) {


### PR DESCRIPTION
Previously URIs like `?sabreAction=asset&assetName=../../../../../../../../../../../Users/lreschke/Programming/core/3rdparty/sabre/dav/lib/DAV/Browser/assets/sabredav.css` could have been used as  `realpath` does resolve them properly.

As discussed in https://github.com/owncloud/core/commit/1edd6d7d0b15a3fd0ad7b20107ac0c603f63204c#commitcomment-9804349

@evert As discussed.