### PR TITLE
[Client] Use file not found exception on 404 HTTP status in propFind

### DIFF
--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -240,6 +240,10 @@ class Client extends HTTP\Client {
         $response = $this->send($request);
 
         if ((int)$response->getStatus() >= 400) {
+            if ((int)$response->getStatus() === 404) {
+                throw new Exception\NotFound($url . ' not found');
+            }
+
             throw new Exception('HTTP error: ' . $response->getStatus());
         }
 

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -163,6 +163,20 @@ XML;
 
     }
 
+    /**
+     * @expectedException \Sabre\DAV\Exception\NotFound
+     */
+    function testPropFindNotFound() {
+
+        $client = new ClientMock([
+            'baseUri' => '/',
+        ]);
+
+        $client->response = new Response(404, []);
+        $client->propfind('foo', ['{DAV:}displayname', '{urn:zim}gir']);
+
+    }
+
     function testPropFindDepth1() {
 
         $client = new ClientMock([


### PR DESCRIPTION
Use file not found exception on 404 HTTP status in propFind, because a 404 is a exceptional case. So the calling code/library can catch on the 404 and handle and ignore all other exceptions, which must be handled in the application on a higher level or be shown.

Be best would be an exception chooser based, which chooses the correct exception based on the HTTP status, but at the moment I had time for this fix only.