### PR TITLE
Allow to use more recent sabre/http

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4.1",
         "sabre/vobject": "~3.3",
         "sabre/event" : "~2.0.0",
-        "sabre/http" : "4.0.0-alpha1",
+        "sabre/http" : "~4.0.0-alpha1",
         "sabre/uri" : "~1.0",
         "ext-dom": "*",
         "ext-pcre": "*",


### PR DESCRIPTION
It’s useful, e.g., for distribution, where the version is suffixed with a distribution-specific string.
E.g., Debian currently ships php-sabre-http 4.0.0~alpha1-1 in experimental.
  https://packages.debian.org/source/experimental/php-sabre-http