### PR TITLE
Use an iterator to get properties for nodes on demand

### DIFF
--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -576,7 +576,7 @@ class Plugin extends DAV\ServerPlugin {
 
             // This array should have only 1 element, the first calendar
             // object.
-            $properties = current($properties);
+            $properties = $properties->current();
 
             // If there wasn't any calendar-data returned somehow, we ignore
             // this.

--- a/lib/CardDAV/VCFExportPlugin.php
+++ b/lib/CardDAV/VCFExportPlugin.php
@@ -87,7 +87,7 @@ class VCFExportPlugin extends DAV\ServerPlugin {
      * @param array $nodes
      * @return string
      */
-    function generateVCF(array $nodes) {
+    function generateVCF($nodes) {
 
         $output = "";
 

--- a/lib/DAV/PropFind.php
+++ b/lib/DAV/PropFind.php
@@ -101,7 +101,8 @@ class PropFind {
             }
             if (!is_null($value)) {
                 $this->itemsLeft--;
-                $this->result[$propertyName] = [200, $value];
+                $this->result[$propertyName][0] = 200;
+                $this->result[$propertyName][1] = $value;
             }
         }
 
@@ -174,6 +175,9 @@ class PropFind {
      * @return void
      */
     function setPath($path) {
+        if ($path !== $this->path) {
+            $this->clear();
+        }
 
         $this->path = $path;
 
@@ -276,6 +280,14 @@ class PropFind {
         if ($this->requestType === self::ALLPROPS) unset($r[404]);
         return $r;
 
+    }
+
+    function clear() {
+        foreach ($this->result as &$info) {
+            $info[0] = 404;
+            $info[1] = null;
+        }
+        $this->itemsLeft = count($this->result);
     }
 
     /**

--- a/lib/DAV/PropFindIterator.php
+++ b/lib/DAV/PropFindIterator.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Sabre\DAV;
+
+class PropFindIterator implements \Iterator, \ArrayAccess
+{
+    /**
+     * @var PropFind
+     */
+    private $propFind;
+
+    /**
+     * @var \SeekableIterator
+     */
+    private $nodes;
+
+    /**
+     * @var Server
+     */
+    private $server;
+
+    public function __construct(PropFind $propFind, \SeekableIterator $nodes, Server $server)
+    {
+        $this->propFind = $propFind;
+        $this->nodes = $nodes;
+        $this->server = $server;
+    }
+
+    public function current()
+    {
+        /**
+         * @var INode $node
+         * @var string $path;
+         */
+        list($node, $path) = $this->nodes->current();
+        $this->propFind->setPath($path);
+        $r = $this->server->getPropertiesByNode($this->propFind, $node);
+        if ($r) {
+            $result = $this->propFind->getResultForMultiStatus();
+            $result['href'] = $this->propFind->getPath();
+
+            // WebDAV recommends adding a slash to the path, if the path is
+            // a collection.
+            // Furthermore, iCal also demands this to be the case for
+            // principals. This is non-standard, but we support it.
+            $resourceType = $this->server->getResourceTypeForNode($node);
+            if (in_array('{DAV:}collection', $resourceType) || in_array('{DAV:}principal', $resourceType)) {
+                $result['href'] .= '/';
+            }
+            return $result;
+        }
+        return [];
+    }
+
+    public function key()
+    {
+        return $this->nodes->key();
+    }
+
+    public function next()
+    {
+        $this->nodes->next();
+    }
+
+    public function rewind()
+    {
+        $this->nodes->rewind();
+    }
+
+    public function valid()
+    {
+        return $this->nodes->valid();
+    }
+
+    public function offsetSet($offset, $value)
+    {
+        throw new Exception();
+    }
+
+    public function offsetExists($offset)
+    {
+        $current = $this->nodes->key();
+        try {
+            $this->nodes->seek($offset);
+            $exists = true;
+        } catch (\OutOfBoundsException $e) {
+            $exists = false;
+        }
+        $this->nodes->seek($current);
+        return $exists;
+    }
+
+    public function offsetUnset($offset)
+    {
+        throw new Exception();
+    }
+
+    public function offsetGet($offset)
+    {
+        $current = $this->nodes->key();
+        $this->nodes->seek($offset);
+        $result = $this->current();
+        $this->nodes->seek($current);
+        return $result;
+    }
+}

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -900,7 +900,7 @@ class Server extends EventEmitter {
      * @param string $path
      * @param array $propertyNames
      * @param int $depth
-     * @return array
+     * @return PropFindIterator
      */
     function getPropertiesForPath($path, $propertyNames = [], $depth = 0) {
 

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -866,28 +866,23 @@ class Server extends EventEmitter {
     /**
      * Small helper to support PROPFIND with DEPTH_INFINITY.
      */
-    private function addPathNodesRecursively(&$propFindRequests, PropFind $propFind) {
+    private function addPathNodesRecursively(&$nodes, $path, $depth) {
 
-        $newDepth = $propFind->getDepth();
-        $path = $propFind->getPath();
+        $newDepth = $depth;
 
         if ($newDepth !== self::DEPTH_INFINITY) {
             $newDepth--;
         }
 
         foreach($this->tree->getChildren($path) as $childNode) {
-            $subPropFind = clone $propFind;
-            $subPropFind->setDepth($newDepth);
-            $subPath = $path? $path . '/' . $childNode->getName() : $childNode->getName();
-            $subPropFind->setPath($subPath);
-
-            $propFindRequests[] = [
-                $subPropFind,
-                $childNode
+            $subPath = $path ? $path . '/' . $childNode->getName() : $childNode->getName();
+            $nodes[] = [
+                $childNode,
+                $subPath
             ];
 
             if (($newDepth===self::DEPTH_INFINITY || $newDepth>=1) && $childNode instanceof ICollection) {
-                $this->addPathNodesRecursively($propFindRequests, $subPropFind);
+                $this->addPathNodesRecursively($nodes, $subPath, $newDepth);
             }
 
         }
@@ -919,39 +914,16 @@ class Server extends EventEmitter {
 
         $parentNode = $this->tree->getNodeForPath($path);
 
-        $propFindRequests = [[
-            $propFind,
-            $parentNode
+        $nodes = [[
+            $parentNode,
+            $path
         ]];
 
         if (($depth > 0 || $depth === self::DEPTH_INFINITY) && $parentNode instanceof ICollection) {
-            $this->addPathNodesRecursively($propFindRequests, $propFind);
+            $this->addPathNodesRecursively($nodes, $propFind->getPath(), $propFind->getDepth());
         }
 
-        $returnPropertyList = [];
-
-        foreach($propFindRequests as $propFindRequest) {
-
-            list($propFind, $node) = $propFindRequest;
-            $r = $this->getPropertiesByNode($propFind, $node);
-            if ($r) {
-                $result = $propFind->getResultForMultiStatus();
-                $result['href'] = $propFind->getPath();
-
-                // WebDAV recommends adding a slash to the path, if the path is
-                // a collection.
-                // Furthermore, iCal also demands this to be the case for
-                // principals. This is non-standard, but we support it.
-                $resourceType = $this->getResourceTypeForNode($node);
-                if (in_array('{DAV:}collection', $resourceType) || in_array('{DAV:}principal', $resourceType)) {
-                    $result['href'].='/';
-                }
-                $returnPropertyList[] = $result;
-            }
-
-        }
-
-        return $returnPropertyList;
+        return new PropFindIterator($propFind, new \ArrayIterator($nodes), $this);
 
     }
 
@@ -1632,11 +1604,11 @@ class Server extends EventEmitter {
      *
      * If 'strip404s' is set to true, all 404 responses will be removed.
      *
-     * @param array $fileProperties The list with nodes
-     * @param bool strip404s
+     * @param array | \Iterator $fileProperties The list with nodes
+     * @param bool $strip404s
      * @return string
      */
-    function generateMultiStatus(array $fileProperties, $strip404s = false) {
+    function generateMultiStatus($fileProperties, $strip404s = false) {
 
         $dom = new \DOMDocument('1.0','utf-8');
         //$dom->formatOutput = true;


### PR DESCRIPTION
This saves having to keep the properties of all nodes in memory before we generate the xml.

Additionally since it now re-uses the same `PropFind` object to store the result it saves having to create and gc additional objects for each file in the propfind.

When testing using ownClouds's sabre implementation this saves 50% of memory when doing a propfind on a folder containing 10k files ([comparison](https://blackfire.io/profiles/compare/b3efda1d-741a-4f26-9e8e-9aeda345a6ce/graph))