### PR TITLE
Remove the need of temp files from the handling of Range requests

### DIFF
--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -170,14 +170,16 @@ class CorePlugin extends ServerPlugin {
 
             }
 
-            // fseek will return 0 only if $stream is seekable (and -1 otherwise)
             // for a seekable $body stream we simply set the pointer
             // for a non-seekable $body stream we read and discard just the
-            //  right amount of data
-            if ((fseek($body, $start, SEEK_SET)) !== 0) {
-                $consume_block = 4096;
+            // right amount of data
+            if (stream_get_meta_data($body)['seekable']) {
+                fseek($body, $start, SEEK_SET);
+            } else {
+                $consumeBlock = 8192;
                 for($consumed = 0; $start - $consumed > 0; ){
-                    $consumed += strlen(fread($body, min($start - $consumed, $consume_block)));
+                    if(feof($body)) throw new Exception\RequestedRangeNotSatisfiable('The start offset (' . $start . ') exceeded the size of the entity (' . $consumed . ')');
+                    $consumed += strlen(fread($body, min($start - $consumed, $consumeBlock)));
                 }
             }
 

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -170,24 +170,21 @@ class CorePlugin extends ServerPlugin {
 
             }
 
-            // New read/write stream
-            $newStream = fopen('php://temp','r+');
-
-            // fseek will return 0 only if $streem is seekable (and -1 otherwise)
-            // for a seekable $body stream we set the pointer write before copying it
-            // for a non-seekable $body stream we set the pointer on the copy
-            if ((fseek($body, $start, SEEK_SET)) === 0) {
-                stream_copy_to_stream($body, $newStream, $end - $start + 1, $start);
-                rewind($newStream);
-            } else {
-                stream_copy_to_stream($body, $newStream, $end + 1);
-                fseek($newStream,$start, SEEK_SET);
+            // fseek will return 0 only if $stream is seekable (and -1 otherwise)
+            // for a seekable $body stream we simply set the pointer
+            // for a non-seekable $body stream we read and discard just the
+            //  right amount of data
+            if ((fseek($body, $start, SEEK_SET)) !== 0) {
+                $consume_block = 4096;
+                for($consumed = 0; $start - $consumed > 0; ){
+                    $consumed += strlen(fread($body, min($start - $consumed, $consume_block)));
+                }
             }
 
             $response->setHeader('Content-Length', $end - $start + 1);
             $response->setHeader('Content-Range','bytes ' . $start . '-' . $end . '/' . $nodeSize);
             $response->setStatus(206);
-            $response->setBody($newStream);
+            $response->setBody($body);
 
         } else {
 

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -38,7 +38,7 @@ class ServerRangeTest extends AbstractServer{
          );
 
         $this->assertEquals(206, $this->response->status);
-        $this->assertEquals('st c', stream_get_contents($this->response->body));
+        $this->assertEquals('st c', stream_get_contents($this->response->body, 4));
 
     }
 
@@ -70,7 +70,7 @@ class ServerRangeTest extends AbstractServer{
          );
 
         $this->assertEquals(206, $this->response->status);
-        $this->assertEquals('st contents', stream_get_contents($this->response->body));
+        $this->assertEquals('st contents', stream_get_contents($this->response->body, 11));
 
     }
 
@@ -102,7 +102,7 @@ class ServerRangeTest extends AbstractServer{
          );
 
         $this->assertEquals(206, $this->response->status);
-        $this->assertEquals('contents', stream_get_contents($this->response->body));
+        $this->assertEquals('contents', stream_get_contents($this->response->body, 8));
 
     }
 
@@ -175,7 +175,7 @@ class ServerRangeTest extends AbstractServer{
          );
 
         $this->assertEquals(206, $this->response->status);
-        $this->assertEquals('st c', stream_get_contents($this->response->body));
+        $this->assertEquals('st c', stream_get_contents($this->response->body, 4));
 
     }
 
@@ -244,7 +244,7 @@ class ServerRangeTest extends AbstractServer{
          );
 
         $this->assertEquals(206, $this->response->status);
-        $this->assertEquals('st c', stream_get_contents($this->response->body));
+        $this->assertEquals('st c', stream_get_contents($this->response->body, 4));
 
     }
 


### PR DESCRIPTION
This commit requires fruux/sabre-http#45 to work.

The other day, I tried to play a 10 gig HD movie from my Owncloud server through GVFS. It failed, and hanged my server by forcing PHP to create humongous temp files. (see owncloud/core#15321) As it turns out, the problem was with HTTP Range requests: SabreDAV decided to create temp files with the the entire contents of the range (GVFS requested ranges like 40960-). So I went ahead to create this pair of small patches.

I am looking forward to hearing your opinion on the matter. Sorry for not opening a discussion beforehand, but discussing it would have taken longer than writing it.

And yes, with these applied, I *have* managed to play the video, at least in a separate SabreDAV install.