### PR TITLE
Removed me-card workaround.

### DIFF
--- a/bin/migrateto22.php
+++ b/bin/migrateto22.php
@@ -10,8 +10,10 @@ if ($argc<2) {
 This script help you migrate from a pre-2.2 database to 2.2 and later
 
 Changes:
-  * Values in the propertystorage table are now serialized using PHP's
-    serialize()
+  * The propertystorage table has changed to allow storage of complex
+    properties.
+  * the vcardurl field in the principals table is no more. This was moved to
+    the propertystorage table.
 
 Keep in mind that ALTER TABLE commands will be executed. If you have a large
 dataset this may mean that this process takes a while.
@@ -83,8 +85,40 @@ try {
     $row = $result->fetch(\PDO::FETCH_ASSOC);
 
     if (!$row) {
-        echo "No data in table. Going to try to add the uid field anyway.\n";
-        $addValueType = true;
+        echo "No data in table. Going to re-create the table.\n";
+        $random = mt_rand(1000,9999);
+        echo "Renaming propertystorage -> propertystorage_old$random and creating new table.\n";
+
+        switch($driver) {
+
+            case 'mysql' :
+                $pdo->exec('RENAME TABLE propertystorage TO propertystorage_old' . $random);
+                $pdo->exec('
+    CREATE TABLE propertystorage (
+        id INT UNSIGNED NOT NULL PRIMARY KEY AUTO_INCREMENT,
+        path VARBINARY(1024) NOT NULL,
+        name VARBINARY(100) NOT NULL,
+        valuetype INT UNSIGNED,
+        value MEDIUMBLOB
+    );
+                ');
+                $pdo->exec('CREATE UNIQUE INDEX path_property_' . $random . '  ON propertystorage (path(600), name(100));');
+                break;
+            case 'sqlite' :
+                $pdo->exec('ALTER TABLE propertystorage RENAME TO propertystorage_old' . $random);
+                $pdo->exec('
+CREATE TABLE propertystorage (
+    id integer primary key asc,
+    path text,
+    name text,
+    valuetype integer,
+    value blob
+);');
+
+                $pdo->exec('CREATE UNIQUE INDEX path_property_' . $random . ' ON propertystorage (path, name);');
+                break;
+
+        }
     } elseif (array_key_exists('valuetype', $row)) {
         echo "valuetype field exists. Assuming that this part of the migration has\n";
         echo "Already been completed.\n";
@@ -96,6 +130,7 @@ try {
 } catch (Exception $e) {
     echo "Could not find a propertystorage table. Skipping this part of the\n";
     echo "upgrade.\n";
+    echo $e->getMessage(), "\n";
 }
 
 if ($addValueType) {
@@ -111,6 +146,24 @@ if ($addValueType) {
     }
 
     $pdo->exec('UPDATE propertystorage SET valuetype = 1 WHERE valuetype IS NULL ');
+
+}
+
+echo "Migrating vcardurl\n";
+
+$result = $pdo->query('SELECT id, uri, vcardurl FROM principals WHERE vcardurl IS NOT NULL');
+$stmt1 = $pdo->prepare('INSERT INTO propertystorage (path, name, valuetype, value) VALUES (?, ?, 3, ?)');
+
+while($row = $result->fetch(\PDO::FETCH_ASSOC)) {
+
+    // Inserting the new record
+    $stmt1->execute([
+        'addressbooks/' . basename($row['uri']),
+        '{http://calendarserver.org/ns/}me-card',
+        serialize(new Sabre\DAV\Xml\Property\Href($row['vcardurl']))
+    ]);
+
+    echo serialize(new Sabre\DAV\Xml\Property\Href($row['vcardurl']));
 
 }
 

--- a/examples/sql/mysql.principals.sql
+++ b/examples/sql/mysql.principals.sql
@@ -3,7 +3,6 @@ CREATE TABLE principals (
     uri VARCHAR(200) NOT NULL,
     email VARCHAR(80),
     displayname VARCHAR(80),
-    vcardurl VARCHAR(255),
     UNIQUE(uri)
 );
 

--- a/examples/sql/pgsql.principals.sql
+++ b/examples/sql/pgsql.principals.sql
@@ -2,8 +2,7 @@ CREATE TABLE principals (
     id SERIAL NOT NULL,
     uri VARCHAR(200) NOT NULL,
     email VARCHAR(80),
-    displayname VARCHAR(80),
-    vcardurl VARCHAR(255)
+    displayname VARCHAR(80)
 );
 
 ALTER TABLE ONLY principals

--- a/examples/sql/sqlite.principals.sql
+++ b/examples/sql/sqlite.principals.sql
@@ -3,7 +3,6 @@ CREATE TABLE principals (
     uri TEXT,
     email TEXT,
     displayname TEXT,
-    vcardurl TEXT,
     UNIQUE(uri)
 );
 

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -42,25 +42,6 @@ class PluginTest extends AbstractPluginTest {
 
     }
 
-    function testMeCardTest() {
-
-        $result = $this->server->getProperties(
-            'addressbooks/user1',
-            array(
-                '{http://calendarserver.org/ns/}me-card',
-            )
-        );
-
-        $this->assertEquals(
-            array(
-                '{http://calendarserver.org/ns/}me-card' =>
-                    new Href('addressbooks/user1/book1/vcard1.vcf')
-            ),
-            $result
-        );
-
-    }
-
     function testDirectoryGateway() {
 
         $result = $this->server->getProperties('principals/user1', array('{' . Plugin::NS_CARDDAV . '}directory-gateway'));
@@ -107,36 +88,6 @@ class PluginTest extends AbstractPluginTest {
         }
         if (!$newAddressBook)
             $this->fail('Could not find newly created addressbook');
-
-    }
-
-    function testUpdatePropertiesMeCard() {
-
-        $result = $this->server->updateProperties('addressbooks/user1', [
-            '{http://calendarserver.org/ns/}me-card' => new Href('/addressbooks/user1/book1/vcard2',true),
-        ]);
-
-        $this->assertEquals(
-            [
-                '{http://calendarserver.org/ns/}me-card' => 200,
-            ],
-            $result
-        );
-
-    }
-
-    function testUpdatePropertiesMeCardBadValue() {
-
-        $result = $this->server->updateProperties('addressbooks/user1', [
-            '{http://calendarserver.org/ns/}me-card' => [],
-        ]);
-
-        $this->assertEquals(
-            [
-                '{http://calendarserver.org/ns/}me-card' => 400,
-            ],
-            $result
-        );
 
     }
 


### PR DESCRIPTION
The property storage plugin can now handle complex values, so it's no
longer needed to have special support for the me-card.

This patch removes all me-card functionality and adds some stuff to the
migrate script to move it over with ease.