### PR TITLE
Refactoring MKCOL and extended collections

### DIFF
--- a/lib/CalDAV/CalendarHome.php
+++ b/lib/CalDAV/CalendarHome.php
@@ -231,7 +231,7 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL {
     }
 
     /**
-     * Creates a new addressbook.
+     * Creates a new calendar or subscription.
      *
      * @param string $name
      * @param MkCol $mkCol

--- a/lib/CalDAV/CalendarHome.php
+++ b/lib/CalDAV/CalendarHome.php
@@ -5,6 +5,7 @@ namespace Sabre\CalDAV;
 use
     Sabre\DAV,
     Sabre\DAV\Exception\NotFound,
+    Sabre\DAV\MkCol,
     Sabre\DAVACL,
     Sabre\HTTP\URLUtil;
 
@@ -230,18 +231,18 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL {
     }
 
     /**
-     * Creates a new calendar
+     * Creates a new calendar or subscription.
      *
      * @param string $name
-     * @param array $resourceType
-     * @param array $properties
+     * @param MkCol $mkCol
+     * @throws DAV\Exception\InvalidResourceType
      * @return void
      */
-    function createExtendedCollection($name, array $resourceType, array $properties) {
+    function createExtendedCollection($name, MkCol $mkCol) {
 
         $isCalendar = false;
         $isSubscription = false;
-        foreach($resourceType as $rt) {
+        foreach($mkCol->getResourceType() as $rt) {
             switch ($rt) {
                 case '{DAV:}collection' :
                 case '{http://calendarserver.org/ns/}shared-owner' :
@@ -257,6 +258,10 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL {
                     throw new DAV\Exception\InvalidResourceType('Unknown resourceType: ' . $rt);
             }
         }
+
+        $properties = $mkCol->getRemainingValues();
+        $mkCol->setRemainingResultCode(201);
+
         if ($isSubscription) {
             if (!$this->caldavBackend instanceof Backend\SubscriptionSupport) {
                 throw new DAV\Exception\InvalidResourceType('This backend does not support subscriptions');

--- a/lib/CalDAV/CalendarHome.php
+++ b/lib/CalDAV/CalendarHome.php
@@ -231,7 +231,7 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL {
     }
 
     /**
-     * Creates a new calendar or subscription.
+     * Creates a new addressbook.
      *
      * @param string $name
      * @param MkCol $mkCol

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -288,7 +288,7 @@ class Plugin extends DAV\ServerPlugin {
             $resourceType = ['{DAV:}collection','{urn:ietf:params:xml:ns:caldav}calendar'];
         }
 
-        $this->server->createCollection($path,new MkCol($resourceType, $properties));
+        $this->server->createCollection($path, new MkCol($resourceType, $properties));
 
         $this->server->httpResponse->setStatus(201);
         $this->server->httpResponse->setHeader('Content-Length',0);

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -6,6 +6,7 @@ use
     DateTimeZone,
     Sabre\DAV,
     Sabre\DAV\Exception\BadRequest,
+    Sabre\DAV\MkCol,
     Sabre\DAV\Xml\Property\Href,
     Sabre\DAVACL,
     Sabre\VObject,
@@ -287,7 +288,7 @@ class Plugin extends DAV\ServerPlugin {
             $resourceType = ['{DAV:}collection','{urn:ietf:params:xml:ns:caldav}calendar'];
         }
 
-        $this->server->createCollection($path,$resourceType,$properties);
+        $this->server->createCollection($path,new MkCol($resourceType, $properties));
 
         $this->server->httpResponse->setStatus(201);
         $this->server->httpResponse->setHeader('Content-Length',0);
@@ -926,7 +927,7 @@ class Plugin extends DAV\ServerPlugin {
         if (isset($postVars['{DAV:}displayname'])) {
             $properties['{DAV:}displayname'] = $postVars['{DAV:}displayname'];
         }
-        $this->server->createCollection($uri . '/' . $postVars['name'],$resourceType,$properties);
+        $this->server->createCollection($uri . '/' . $postVars['name'], new MkCol($resourceType,$properties));
         return false;
 
     }

--- a/lib/CardDAV/AddressBookHome.php
+++ b/lib/CardDAV/AddressBookHome.php
@@ -4,19 +4,20 @@ namespace Sabre\CardDAV;
 
 use
     Sabre\DAV,
+    Sabre\DAV\MkCol,
     Sabre\DAVACL,
-    Sabre\HTTP\URLUtil;
+    Sabre\Uri;
 
 /**
- * UserAddressBooks class
+ * AddressBook Home class
  *
- * The UserAddressBooks collection contains a list of addressbooks associated with a user
+ * This collection contains a list of addressbooks associated with one user.
  *
  * @copyright Copyright (C) 2007-2015 fruux GmbH (https://fruux.com/).
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class UserAddressBooks extends DAV\Collection implements DAV\IExtendedCollection, DAVACL\IACL {
+class AddressBookHome extends DAV\Collection implements DAV\IExtendedCollection, DAVACL\IACL {
 
     /**
      * Principal uri
@@ -52,7 +53,7 @@ class UserAddressBooks extends DAV\Collection implements DAV\IExtendedCollection
      */
     function getName() {
 
-        list(,$name) = URLUtil::splitPath($this->principalUri);
+        list(,$name) = Uri\split($this->principalUri);
         return $name;
 
     }
@@ -155,18 +156,20 @@ class UserAddressBooks extends DAV\Collection implements DAV\IExtendedCollection
     }
 
     /**
-     * Creates a new addressbook
+     * Creates a new calendar or subscription.
      *
      * @param string $name
-     * @param array $resourceType
-     * @param array $properties
+     * @param MkCol $mkCol
+     * @throws DAV\Exception\InvalidResourceType
      * @return void
      */
-    function createExtendedCollection($name, array $resourceType, array $properties) {
+    function createExtendedCollection($name, MkCol $mkCol) {
 
-        if (!in_array('{'.Plugin::NS_CARDDAV.'}addressbook',$resourceType) || count($resourceType)!==2) {
+        if (!$mkCol->hasResourceType('{'.Plugin::NS_CARDDAV.'}addressbook')) {
             throw new DAV\Exception\InvalidResourceType('Unknown resourceType for this collection');
         }
+        $properties = $mkCol->getRemainingValues();
+        $mkCol->setRemainingStatus(201);
         $this->carddavBackend->createAddressBook($this->principalUri, $name, $properties);
 
     }

--- a/lib/CardDAV/AddressBookHome.php
+++ b/lib/CardDAV/AddressBookHome.php
@@ -156,7 +156,7 @@ class AddressBookHome extends DAV\Collection implements DAV\IExtendedCollection,
     }
 
     /**
-     * Creates a new calendar or subscription.
+     * Creates a new address book.
      *
      * @param string $name
      * @param MkCol $mkCol

--- a/lib/CardDAV/AddressBookHome.php
+++ b/lib/CardDAV/AddressBookHome.php
@@ -169,7 +169,7 @@ class AddressBookHome extends DAV\Collection implements DAV\IExtendedCollection,
             throw new DAV\Exception\InvalidResourceType('Unknown resourceType for this collection');
         }
         $properties = $mkCol->getRemainingValues();
-        $mkCol->setRemainingStatus(201);
+        $mkCol->setRemainingResultCode(201);
         $this->carddavBackend->createAddressBook($this->principalUri, $name, $properties);
 
     }

--- a/lib/CardDAV/AddressBookRoot.php
+++ b/lib/CardDAV/AddressBookRoot.php
@@ -73,7 +73,7 @@ class AddressBookRoot extends DAVACL\AbstractPrincipalCollection {
      */
     function getChildForPrincipal(array $principal) {
 
-        return new UserAddressBooks($this->carddavBackend, $principal['uri']);
+        return new AddressBookHome($this->carddavBackend, $principal['uri']);
 
     }
 

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -2,17 +2,17 @@
 
 namespace Sabre\CardDAV;
 
-use Sabre\DAV;
-use Sabre\DAVACL;
-use Sabre\VObject;
+use
+    Sabre\DAV,
+    Sabre\DAV\Exception\ReportNotSupported,
+    Sabre\DAV\MkCol,
+    Sabre\DAV\Xml\Property\Href,
+    Sabre\DAVACL,
+    Sabre\HTTP,
+    Sabre\HTTP\RequestInterface,
+    Sabre\HTTP\ResponseInterface,
+    Sabre\VObject;
 
-use Sabre\DAV\Exception\ReportNotSupported;
-
-use Sabre\HTTP;
-use Sabre\HTTP\RequestInterface;
-use Sabre\HTTP\ResponseInterface;
-
-use Sabre\DAV\Xml\Property\Href;
 
 /**
  * CardDAV plugin
@@ -800,7 +800,7 @@ class Plugin extends DAV\ServerPlugin {
         if (isset($postVars['{DAV:}displayname'])) {
             $properties['{DAV:}displayname'] = $postVars['{DAV:}displayname'];
         }
-        $this->server->createCollection($uri . '/' . $postVars['name'],$resourceType,$properties);
+        $this->server->createCollection($uri . '/' . $postVars['name'], new MkCol($resourceType,$properties));
         return false;
 
     }

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -681,7 +681,7 @@ class Plugin extends DAV\ServerPlugin {
      */
     function htmlActionsPanel(DAV\INode $node, &$output) {
 
-        if (!$node instanceof UserAddressBooks)
+        if (!$node instanceof AddressBookHome)
             return;
 
         $output.= '<tr><td colspan="2"><form method="post" action="">

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -586,7 +586,9 @@ class CorePlugin extends ServerPlugin {
 
         }
 
-        $result = $this->server->createCollection($path, $resourceType, $properties);
+        $mkcol = new MkCol($resourceType, $properties);
+
+        $result = $this->server->createCollection($path, $mkcol);
 
         if (is_array($result)) {
             $response->setStatus(207);

--- a/lib/DAV/IExtendedCollection.php
+++ b/lib/DAV/IExtendedCollection.php
@@ -15,14 +15,30 @@ namespace Sabre\DAV;
 interface IExtendedCollection extends ICollection {
 
     /**
-     * Creates a new collection
+     * Creates a new collection.
+     *
+     * This method will receive MkCol object with all the information about the
+     * new collection that's being created.
+     *
+     * The MkCol object contains information about the resourceType of the new
+     * collection. If you don't support the specified resourceType, you should
+     * throw Exception\InvalidResourceType.
+     *
+     * The object also contains a list of WebDAV properties for the new
+     * collection.
+     *
+     * You should call the handle() method on this object to specify exactly
+     * which properties you are storing. This allows the system to figure out
+     * exactly which properties you didn't store, which in turn allows other
+     * plugins (such as the propertystorage plugin) to handle storing the
+     * property for you.
      *
      * @param string $name
-     * @param array $resourceType
-     * @param array $properties
+     * @param MkCol $mkCol
+     * @throws Exception\InvalidResourceType
      * @return void
      */
-    function createExtendedCollection($name, array $resourceType, array $properties);
+    function createExtendedCollection($name, MkCol $mkCol);
 
 }
 

--- a/lib/DAV/IExtendedCollection.php
+++ b/lib/DAV/IExtendedCollection.php
@@ -17,8 +17,8 @@ interface IExtendedCollection extends ICollection {
     /**
      * Creates a new collection.
      *
-     * This method will receive MkCol object with all the information about the
-     * new collection that's being created.
+     * This method will receive a MkCol object with all the information about
+     * the new collection that's being created.
      *
      * The MkCol object contains information about the resourceType of the new
      * collection. If you don't support the specified resourceType, you should

--- a/lib/DAV/MkCol.php
+++ b/lib/DAV/MkCol.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Sabre\DAV;
+
+use UnexpectedValueException;
+
+/**
+ * This class represents a MKCOL operation.
+ *
+ * MKCOL creates a new collection. MKCOL comes in two flavours:
+ *
+ * 1. MKCOL with no body, signifies the creation of a simple collection.
+ * 2. MKCOL with a request body. This can create a collection with a specific
+ *    resource type, and a set of properties that should be set on the new
+ *    collection. This can be used to create caldav calendars, carddav address
+ *    books, etc.
+ *
+ * Property updates must always be atomic. This means that a property update
+ * must either completely succeed, or completely fail.
+ *
+ * @copyright Copyright (C) 2007-2015 fruux GmbH (https://fruux.com/).
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class MkCol extends PropPatch {
+
+    /**
+     * A list of resource-types in clark-notation.
+     * 
+     * @var array 
+     */
+    protected $resourceType;
+
+    /**
+     * Creates the MKCOL object.
+     * 
+     * @param string[] $resourceType List of resourcetype values. 
+     * @param array $mutations List of new properties values.
+     */
+    function __construct(array $resourceType, array $mutations) {
+
+        $this->resourceType = $resourceType;
+        parent::__construct($mutations);
+
+    }
+
+    /**
+     * Returns the resourcetype of the new collection.
+     *
+     * @return string[]
+     */
+    function getResourceType() {
+
+        return $this->resourceType;
+
+    }
+
+    /**
+     * Returns true or false if the MKCOL operation has at least the specified
+     * resource type.
+     *
+     * If the resourcetype is specified as an array, all resourcetypes are
+     * checked.
+     *
+     * @param string|string[] $resourceType
+     */
+    function hasResourceType($resourceType) {
+
+        return count(array_diff((array)$resourceType, $this->resourceType)) === 0;
+
+    }
+
+}

--- a/lib/DAV/PropPatch.php
+++ b/lib/DAV/PropPatch.php
@@ -170,7 +170,9 @@ class PropPatch {
     /**
      * Returns the list of properties that don't have a result code yet.
      *
-     * @return array
+     * This method returns a list of property names, but not its values.
+     *
+     * @return string[]
      */
     function getRemainingMutations() {
 
@@ -178,6 +180,26 @@ class PropPatch {
         foreach($this->mutations as $propertyName => $propValue) {
             if (!isset($this->result[$propertyName])) {
                 $remaining[] = $propertyName;
+            }
+        }
+
+        return $remaining;
+
+    }
+
+    /**
+     * Returns the list of properties that don't have a result code yet.
+     *
+     * This method returns list of properties and their values.
+     *
+     * @return array
+     */
+    function getRemainingValues() {
+
+        $remaining = [];
+        foreach($this->mutations as $propertyName => $propValue) {
+            if (!isset($this->result[$propertyName])) {
+                $remaining[$propertyName] = $propValue;
             }
         }
 

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1176,7 +1176,12 @@ class Server extends EventEmitter {
         }
         $success = $mkCol->commit();
 
-        if (!$success) return $mkCol->getResult();
+        if (!$success) {
+            $result = $mkCol->getResult();
+            // generateMkCol needs the href key to exist.
+            $result['href'] = $uri;
+            return $result;
+        }
 
         $this->tree->markDirty($parentUri);
         $this->emit('afterBind',[$uri]);

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1095,7 +1095,7 @@ class Server extends EventEmitter {
      */
     function createDirectory($uri) {
 
-        $this->createCollection($uri,new MkCol(['{DAV:}collection'], []));
+        $this->createCollection($uri, new MkCol(['{DAV:}collection'], []));
 
     }
 
@@ -1147,7 +1147,7 @@ class Server extends EventEmitter {
         if ($parent instanceof IExtendedCollection) {
 
             /**
-             * If the parent is an instanced of IExtendedCollection, it means that
+             * If the parent is an instance of IExtendedCollection, it means that
              * we can pass the MkCol object directly as it may be able to store
              * properties immediately.
              */
@@ -1158,7 +1158,7 @@ class Server extends EventEmitter {
             /**
              * If the parent is a standard ICollection, it means only
              * 'standard' collections can be created, so we should fail any
-             * MKCOL operation that carry extra resourcetypes.
+             * MKCOL operation that carries extra resourcetypes.
              */
             if (count($mkCol->getResourceType())>1) {
                 throw new Exception\InvalidResourceType('The {DAV:}resourcetype you specified is not supported here.');

--- a/tests/Sabre/CalDAV/CalendarHomeSubscriptionsTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeSubscriptionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Sabre\CalDAV;
 
-use Sabre\DAVACL;
+use
+    Sabre\DAV\MkCol,
+    Sabre\DAVACL;
 
 class CalendarHomeSubscriptionsTest extends \PHPUnit_Framework_TestCase {
 
@@ -54,7 +56,7 @@ class CalendarHomeSubscriptionsTest extends \PHPUnit_Framework_TestCase {
             '{DAV:}displayname' => 'baz',
             '{http://calendarserver.org/ns/}source' => new \Sabre\DAV\Xml\Property\Href('http://example.org/test2.ics'),
         ];
-        $instance->createExtendedCollection('sub2', $rt, $props);
+        $instance->createExtendedCollection('sub2', new MkCol($rt, $props));
 
         $children = $instance->getChildren();
         $this->assertEquals(2, count($children));
@@ -64,7 +66,7 @@ class CalendarHomeSubscriptionsTest extends \PHPUnit_Framework_TestCase {
     /**
      * @expectedException \Sabre\DAV\Exception\InvalidResourceType
      */
-    public function testNoSubscriptionSupport() {
+    function testNoSubscriptionSupport() {
 
         $principal = [
             'uri' => 'principals/user1'
@@ -78,7 +80,7 @@ class CalendarHomeSubscriptionsTest extends \PHPUnit_Framework_TestCase {
             '{DAV:}displayname' => 'baz',
             '{http://calendarserver.org/ns/}source' => new \Sabre\DAV\Xml\Property\Href('http://example.org/test2.ics'),
         ];
-        $uC->createExtendedCollection('sub2', $rt, $props);
+        $uC->createExtendedCollection('sub2', new MkCol($rt, $props));
 
     }
 

--- a/tests/Sabre/CalDAV/CalendarHomeTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeTest.php
@@ -1,13 +1,13 @@
 <?php
 
 namespace Sabre\CalDAV;
-use Sabre\DAVACL;
-use Sabre\DAV;
 
-require_once 'Sabre/CalDAV/TestUtil.php';
+use
+    Sabre\DAV,
+    Sabre\DAV\MkCol,
+    Sabre\DAVACL;
 
-/**
- */
+
 class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
 
     /**
@@ -161,7 +161,11 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
      */
     function testCreateExtendedCollection() {
 
-        $result = $this->usercalendars->createExtendedCollection('newcalendar', array('{DAV:}collection', '{urn:ietf:params:xml:ns:caldav}calendar'), array());
+        $mkCol = new MkCol(
+            ['{DAV:}collection', '{urn:ietf:params:xml:ns:caldav}calendar'],
+            []
+        );
+        $result = $this->usercalendars->createExtendedCollection('newcalendar', $mkCol);
         $this->assertNull($result);
         $cals = $this->backend->getCalendarsForUser('principals/user1');
         $this->assertEquals(3,count($cals));
@@ -174,7 +178,11 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
      */
     function testCreateExtendedCollectionBadResourceType() {
 
-        $this->usercalendars->createExtendedCollection('newcalendar', array('{DAV:}collection','{DAV:}blabla'), array());
+        $mkCol = new MkCol(
+            ['{DAV:}collection', '{DAV:}blabla'],
+            []
+        );
+        $this->usercalendars->createExtendedCollection('newcalendar', $mkCol);
 
     }
 
@@ -184,7 +192,11 @@ class CalendarHomeTest extends \PHPUnit_Framework_TestCase {
      */
     function testCreateExtendedCollectionNotACalendar() {
 
-        $this->usercalendars->createExtendedCollection('newcalendar', array('{DAV:}collection'), array());
+        $mkCol = new MkCol(
+            ['{DAV:}collection'],
+            []
+        );
+        $this->usercalendars->createExtendedCollection('newcalendar', $mkCol);
 
     }
 

--- a/tests/Sabre/CardDAV/AddressBookHomeTest.php
+++ b/tests/Sabre/CardDAV/AddressBookHomeTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\CardDAV;
 
+use Sabre\DAV\MkCol;
+
 class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
 
     /**
@@ -96,11 +98,11 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
 
     function testCreateExtendedCollection() {
 
-        $resourceType = array(
+        $resourceType = [ 
             '{' . Plugin::NS_CARDDAV . '}addressbook',
             '{DAV:}collection',
-        );
-        $this->s->createExtendedCollection('book2', $resourceType, array('{DAV:}displayname' => 'a-book 2'));
+        ];
+        $this->s->createExtendedCollection('book2', new MkCol($resourceType, ['{DAV:}displayname' => 'a-book 2']));
 
         $this->assertEquals(array(
             'id' => 'book2',
@@ -119,7 +121,7 @@ class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
         $resourceType = array(
             '{DAV:}collection',
         );
-        $this->s->createExtendedCollection('book2', $resourceType, array('{DAV:}displayname' => 'a-book 2'));
+        $this->s->createExtendedCollection('book2', new MkCol($resourceType, array('{DAV:}displayname' => 'a-book 2')));
 
     }
 

--- a/tests/Sabre/CardDAV/AddressBookHomeTest.php
+++ b/tests/Sabre/CardDAV/AddressBookHomeTest.php
@@ -2,10 +2,10 @@
 
 namespace Sabre\CardDAV;
 
-class UserAddressBooksTest extends \PHPUnit_Framework_TestCase {
+class AddressBookHomeTest extends \PHPUnit_Framework_TestCase {
 
     /**
-     * @var Sabre\CardDAV\UserAddressBooks
+     * @var Sabre\CardDAV\AddressBookHome
      */
     protected $s;
     protected $backend;
@@ -13,7 +13,7 @@ class UserAddressBooksTest extends \PHPUnit_Framework_TestCase {
     function setUp() {
 
         $this->backend = new Backend\Mock();
-        $this->s = new UserAddressBooks(
+        $this->s = new AddressBookHome(
             $this->backend,
             'principals/user1'
         );

--- a/tests/Sabre/CardDAV/AddressBookRootTest.php
+++ b/tests/Sabre/CardDAV/AddressBookRootTest.php
@@ -24,7 +24,7 @@ class AddressBookRootTest extends \PHPUnit_Framework_TestCase {
         $children = $root->getChildren();
         $this->assertEquals(3, count($children));
 
-        $this->assertInstanceOf('Sabre\\CardDAV\\UserAddressBooks', $children[0]);
+        $this->assertInstanceOf('Sabre\\CardDAV\\AddressBookHome', $children[0]);
         $this->assertEquals('user1', $children[0]->getName());
 
     }

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -42,25 +42,6 @@ class PluginTest extends AbstractPluginTest {
 
     }
 
-    function testMeCardTest() {
-
-        $result = $this->server->getProperties(
-            'addressbooks/user1',
-            array(
-                '{http://calendarserver.org/ns/}me-card',
-            )
-        );
-
-        $this->assertEquals(
-            array(
-                '{http://calendarserver.org/ns/}me-card' =>
-                    new Href('addressbooks/user1/book1/vcard1.vcf')
-            ),
-            $result
-        );
-
-    }
-
     function testDirectoryGateway() {
 
         $result = $this->server->getProperties('principals/user1', array('{' . Plugin::NS_CARDDAV . '}directory-gateway'));
@@ -107,36 +88,6 @@ class PluginTest extends AbstractPluginTest {
         }
         if (!$newAddressBook)
             $this->fail('Could not find newly created addressbook');
-
-    }
-
-    function testUpdatePropertiesMeCard() {
-
-        $result = $this->server->updateProperties('addressbooks/user1', [
-            '{http://calendarserver.org/ns/}me-card' => new Href('/addressbooks/user1/book1/vcard2',true),
-        ]);
-
-        $this->assertEquals(
-            [
-                '{http://calendarserver.org/ns/}me-card' => 200,
-            ],
-            $result
-        );
-
-    }
-
-    function testUpdatePropertiesMeCardBadValue() {
-
-        $result = $this->server->updateProperties('addressbooks/user1', [
-            '{http://calendarserver.org/ns/}me-card' => [],
-        ]);
-
-        $this->assertEquals(
-            [
-                '{http://calendarserver.org/ns/}me-card' => 400,
-            ],
-            $result
-        );
 
     }
 


### PR DESCRIPTION
The changes we made earlier for PROPPATCH can also be applied to MKCOL.
This patch makes MKCOL and PROPPATCH more consistent with each other,
and also allows the PropertyStorage plugin to hook into MKCOL correctly.

It also renames CardDAV\UserAddressBooks to CardDAV\AddressBookHome to be consistent with CalDAV\CalendarHome.