### PR TITLE
Properties are responsible for their own HTML output

### DIFF
--- a/lib/DAV/Browser/HtmlOutput.php
+++ b/lib/DAV/Browser/HtmlOutput.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Sabre\DAV\Browser;
+
+/**
+ * WebDAV properties that implement this interface are able to generate their
+ * own html output for the browser plugin.
+ *
+ * This is only useful for display purposes, and might make it a bit easier for
+ * people to read and understand the value of some properties.
+ *
+ * @copyright Copyright (C) 2007-2015 fruux GmbH. (https://fruux.com/)
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+interface HtmlOutput {
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html);
+
+}

--- a/lib/DAV/Browser/HtmlOutputHelper.php
+++ b/lib/DAV/Browser/HtmlOutputHelper.php
@@ -107,6 +107,8 @@ class HtmlOutputHelper {
         list($ns, $localName) = XmlService::parseClarkNotation($element);
         if (isset($this->namespaceMap[$ns])) {
             $propName = $this->namespaceMap[$ns] . ':' . $localName;
+        } else {
+            $propName = $element;
         }
         return "<span title=\"" . $this->h($element) . "\">" . $this->h($propName) . "</span>";
 

--- a/lib/DAV/Browser/HtmlOutputHelper.php
+++ b/lib/DAV/Browser/HtmlOutputHelper.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Sabre\DAV\Browser;
+
+use Sabre\Uri;
+use Sabre\Xml\Service as XmlService;
+
+/**
+ * This class provides a few utility functions for easily generating HTML for
+ * the browser plugin.
+ *
+ * @copyright Copyright (C) 2007-2015 fruux GmbH. (https://fruux.com/)
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class HtmlOutputHelper {
+
+    /**
+     * Link to the root of the application.
+     *
+     * @var string
+     */
+    protected $baseUri;
+
+    /**
+     * List of xml namespaces.
+     *
+     * @var array
+     */
+    protected $namespaceMap;
+
+    /**
+     * Creates the object.
+     *
+     * baseUri must point to the root of the application. This will be used to
+     * easily generate links.
+     *
+     * The namespaceMap contains an array with the list of xml namespaces and
+     * their prefixes. WebDAV uses a lot of XML with complex namespaces, so
+     * that can be used to make output a lot shorter.
+     *
+     * @param string $baseUri
+     * @param array $namespaceMap
+     */
+    function __construct($baseUri, array $namespaceMap) {
+
+        $this->baseUri = $baseUri;
+        $this->namespaceMap = $namespaceMap;
+
+    }
+
+    /**
+     * Generates a 'full' url based on a relative one.
+     *
+     * For relative urls, the base of the application is taken as the reference
+     * url, not the 'current url of the current request'.
+     *
+     * Absolute urls are left alone.
+     *
+     * @param string $path
+     * @return string
+     */
+    function fullUrl($path) {
+
+        return Uri\resolve($this->baseUri, $path);
+
+    }
+
+    /**
+     * Escape string for HTML output. 
+     *
+     * @param string $input 
+     * @return string 
+     */
+    function h($input) {
+
+        return htmlspecialchars($input, ENT_COMPAT, 'UTF-8');
+
+    }
+
+    /**
+     * Generates a full <a>-tag.
+     *
+     * Url is automatically expanded. If label is not specified, we re-use the
+     * url. 
+     * 
+     * @param string $url 
+     * @param string $label 
+     * @return string 
+     */
+    function link($url, $label = null) {
+
+        $url = $this->h($this->fullUrl($url));
+        return '<a href="' . $url . '">' . ($label ? $this->h($label) : $url) . '</a>';
+
+    }
+
+    /**
+     * This method takes an xml element in clark-notation, and turns it into a
+     * shortened version with a prefix, if it was a known namespace. 
+     * 
+     * @param string $element
+     * @return string 
+     */
+    function xmlName($element) {
+
+        list($ns, $localName) = XmlService::parseClarkNotation($element);
+        if (isset($this->namespaceMap[$ns])) {
+            $propName = $this->namespaceMap[$ns] . ':' . $localName;
+        }
+        return "<span title=\"" . $this->h($element) . "\">" . $this->h($propName) . "</span>";
+
+    }
+
+}

--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -2,10 +2,11 @@
 
 namespace Sabre\DAV\Xml\Property;
 
-use
-    Sabre\Xml\Element,
-    Sabre\Xml\Reader,
-    Sabre\Xml\Writer;
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
+use Sabre\Xml\Element;
+use Sabre\Xml\Reader;
+use Sabre\Xml\Writer;
 
 /**
  * Href property
@@ -21,7 +22,7 @@ use
  * @author Evert Pot (http://www.rooftopsolutions.nl/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Href implements Element {
+class Href implements Element, HtmlOutput {
 
     /**
      * List of uris
@@ -108,6 +109,30 @@ class Href implements Element {
             }
             $writer->writeElement('{DAV:}href', $href);
         }
+
+    }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        $links = [];
+        foreach($this->getHrefs() as $href) {
+            $links[] = $html->link($href);
+        }
+        return implode('<br />', $links);
 
     }
 

--- a/lib/DAV/Xml/Property/ResourceType.php
+++ b/lib/DAV/Xml/Property/ResourceType.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAV\Xml\Property;
 
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\Xml\Element;
 use Sabre\Xml\Reader;
 
@@ -16,7 +18,7 @@ use Sabre\Xml\Reader;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class ResourceType extends Element\Elements {
+class ResourceType extends Element\Elements implements HtmlOutput {
 
     /**
      * Constructor
@@ -97,6 +99,29 @@ class ResourceType extends Element\Elements {
 
         return
             new self(parent::xmlDeserialize($reader));
+
+    }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        return implode(
+            ', ',
+            array_map([$html, 'xmlName'], $this->getValue())
+        );
 
     }
 

--- a/lib/DAV/Xml/Property/SupportedMethodSet.php
+++ b/lib/DAV/Xml/Property/SupportedMethodSet.php
@@ -2,9 +2,10 @@
 
 namespace Sabre\DAV\Xml\Property;
 
-use
-    Sabre\Xml\Writer,
-    Sabre\Xml\XmlSerializable;
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
+use Sabre\Xml\Writer;
+use Sabre\Xml\XmlSerializable;
 
 /**
  * supported-method-set property.
@@ -16,10 +17,10 @@ use
  * http://tools.ietf.org/html/rfc3253#section-3.1.3
  *
  * @copyright Copyright (C) 2007-2015 fruux GmbH (https://fruux.com/).
- * @author Evert Pot (http://evertpot.com/) 
+ * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class SupportedMethodSet implements XmlSerializable {
+class SupportedMethodSet implements XmlSerializable, HtmlOutput {
 
     /**
      * List of methods
@@ -96,6 +97,29 @@ class SupportedMethodSet implements XmlSerializable {
             $writer->writeAttribute('name', $val);
             $writer->endElement();
         }
+
+    }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        return implode(
+            ', ',
+            array_map([$html, 'h'], $this->getValue())
+        );
 
     }
 

--- a/lib/DAV/Xml/Property/SupportedReportSet.php
+++ b/lib/DAV/Xml/Property/SupportedReportSet.php
@@ -3,6 +3,8 @@
 namespace Sabre\DAV\Xml\Property;
 
 use Sabre\DAV;
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\Xml\Writer;
 use Sabre\Xml\XmlSerializable;
 
@@ -19,7 +21,7 @@ use Sabre\Xml\XmlSerializable;
  * @author Evert Pot (http://www.rooftopsolutions.nl/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class SupportedReportSet implements XmlSerializable {
+class SupportedReportSet implements XmlSerializable, HtmlOutput {
 
     /**
      * List of reports
@@ -123,6 +125,29 @@ class SupportedReportSet implements XmlSerializable {
             $writer->endElement();
             $writer->endElement();
         }
+
+    }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        return implode(
+            ', ',
+            array_map([$html, 'xmlName'], $this->getValue())
+        );
 
     }
 

--- a/lib/DAVACL/Xml/Property/Acl.php
+++ b/lib/DAVACL/Xml/Property/Acl.php
@@ -2,11 +2,12 @@
 
 namespace Sabre\DAVACL\Xml\Property;
 
-use
-    Sabre\DAV,
-    Sabre\Xml\Element,
-    Sabre\Xml\Reader,
-    Sabre\Xml\Writer;
+use Sabre\DAV;
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
+use Sabre\Xml\Element;
+use Sabre\Xml\Reader;
+use Sabre\Xml\Writer;
 
 /**
  * This class represents the {DAV:}acl property.
@@ -24,7 +25,7 @@ use
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class Acl implements Element {
+class Acl implements Element, HtmlOutput {
 
     /**
      * List of privileges
@@ -102,6 +103,46 @@ class Acl implements Element {
             $this->serializeAce($writer, $ace);
 
         }
+
+    }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        ob_start();
+        echo "<table>";
+        echo "<tr><th>Principal</th><th>Privilege</th><th></th>";
+        foreach($this->privileges as $privilege) {
+
+            echo '<tr>';
+            // if it starts with a {, it's a special principal
+            if ($privilege['principal'][0] === '{') {
+                echo '<td>', $html->xmlName($privilege['principal']), '</td>';
+            } else {
+                echo '<td>', $html->link($privilege['principal']), '</td>';
+            }
+            echo '<td>', $html->xmlName($privilege['privilege']), '</td>';
+            echo '<td>';
+            if ($privilege['protected']) { echo '(protected)'; }
+            echo '</td>';
+            echo '</tr>';
+
+        }
+        echo "</table>";
+        return ob_get_clean();
 
     }
 

--- a/lib/DAVACL/Xml/Property/Acl.php
+++ b/lib/DAVACL/Xml/Property/Acl.php
@@ -124,7 +124,7 @@ class Acl implements Element, HtmlOutput {
 
         ob_start();
         echo "<table>";
-        echo "<tr><th>Principal</th><th>Privilege</th><th></th>";
+        echo "<tr><th>Principal</th><th>Privilege</th><th></th></tr>";
         foreach($this->privileges as $privilege) {
 
             echo '<tr>';
@@ -136,7 +136,7 @@ class Acl implements Element, HtmlOutput {
             }
             echo '<td>', $html->xmlName($privilege['privilege']), '</td>';
             echo '<td>';
-            if ($privilege['protected']) echo '(protected)';
+            if (!empty($privilege['protected'])) echo '(protected)';
             echo '</td>';
             echo '</tr>';
 

--- a/lib/DAVACL/Xml/Property/Acl.php
+++ b/lib/DAVACL/Xml/Property/Acl.php
@@ -136,7 +136,7 @@ class Acl implements Element, HtmlOutput {
             }
             echo '<td>', $html->xmlName($privilege['privilege']), '</td>';
             echo '<td>';
-            if ($privilege['protected']) { echo '(protected)'; }
+            if ($privilege['protected']) echo '(protected)';
             echo '</td>';
             echo '</tr>';
 

--- a/lib/DAVACL/Xml/Property/CurrentUserPrivilegeSet.php
+++ b/lib/DAVACL/Xml/Property/CurrentUserPrivilegeSet.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAVACL\Xml\Property;
 
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\Xml\Element;
 use Sabre\Xml\Reader;
 use Sabre\Xml\Writer;
@@ -16,7 +18,7 @@ use Sabre\Xml\Writer;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class CurrentUserPrivilegeSet implements Element {
+class CurrentUserPrivilegeSet implements Element, HtmlOutput {
 
     /**
      * List of privileges
@@ -128,5 +130,29 @@ class CurrentUserPrivilegeSet implements Element {
         return new self($result);
 
     }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        return implode(
+            ', ',
+            array_map([$html, 'xmlName'], $this->getValue())
+        );
+
+    }
+
 
 }

--- a/lib/DAVACL/Xml/Property/SupportedPrivilegeSet.php
+++ b/lib/DAVACL/Xml/Property/SupportedPrivilegeSet.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\DAVACL\Xml\Property;
 
+use Sabre\DAV\Browser\HtmlOutput;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\Xml\XmlSerializable;
 use Sabre\Xml\Writer;
 
@@ -19,7 +21,7 @@ use Sabre\Xml\Writer;
  * @author Evert Pot (http://evertpot.com/)
  * @license http://sabre.io/license/ Modified BSD License
  */
-class SupportedPrivilegeSet implements XmlSerializable {
+class SupportedPrivilegeSet implements XmlSerializable, HtmlOutput {
 
     /**
      * privileges
@@ -74,6 +76,51 @@ class SupportedPrivilegeSet implements XmlSerializable {
         $this->serializePriv($writer, $this->privileges);
 
     }
+
+    /**
+     * Generate html representation for this value.
+     *
+     * The html output is 100% trusted, and no effort is being made to sanitize
+     * it. It's up to the implementor to sanitize user provided values.
+     *
+     * The output must be in UTF-8.
+     *
+     * The baseUri parameter is a url to the root of the application, and can
+     * be used to construct local links.
+     *
+     * @param HtmlOutputHelper $html
+     * @return string
+     */
+    function toHtml(HtmlOutputHelper $html) {
+
+        $traverse = function($priv) use (&$traverse, $html) {
+            echo "<li>";
+            echo $html->xmlName($priv['privilege']);
+            if (isset($priv['abstract']) && $priv['abstract']) {
+                echo " <i>(abstract)</i>";
+            }
+            if (isset($priv['description'])) {
+                echo " " . $html->h($priv['description']);
+            }
+            if (isset($priv['aggregates'])) {
+                echo "\n<ul>\n";
+                foreach($priv['aggregates'] as $subPriv) {
+                    $traverse($subPriv);
+                }
+                echo "</ul>";
+            }
+            echo "</li>\n";
+        };
+
+        ob_start();
+        echo "<ul class=\"tree\">";
+        $traverse($this->getValue(), '');
+        echo "</ul>\n";
+
+        return ob_get_clean();
+
+    }
+
 
 
     /**

--- a/tests/Sabre/DAV/Xml/Property/HrefTest.php
+++ b/tests/Sabre/DAV/Xml/Property/HrefTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\DAV\Xml\Property;
 
 use Sabre\DAV;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\DAV\Xml\XmlTest;
 
 class HrefTest extends XmlTest {
@@ -52,10 +53,10 @@ class HrefTest extends XmlTest {
 
         $result = $this->parse($xml, ['{DAV:}anything' => 'Sabre\\DAV\\Xml\\Property\\Href']);
 
-        $href = $result['value']; 
+        $href = $result['value'];
 
         $this->assertInstanceOf('Sabre\\DAV\\Xml\\Property\\Href', $href);
-        
+
         $this->assertEquals('/bla/path',$href->getHref());
 
     }
@@ -66,7 +67,7 @@ class HrefTest extends XmlTest {
 <d:anything xmlns:d="DAV:"><d:href2>/bla/path</d:href2></d:anything>
 ';
         $result = $this->parse($xml, ['{DAV:}anything' => 'Sabre\\DAV\\Xml\\Property\\Href']);
-        $href = $result['value']; 
+        $href = $result['value'];
         $this->assertNull($href);
 
     }
@@ -85,6 +86,27 @@ class HrefTest extends XmlTest {
 '<?xml version="1.0"?>
 <d:anything xmlns:d="DAV:"><d:href>http://example.org/?a&amp;b</d:href></d:anything>
 ', $xml);
+
+    }
+
+    function testToHtml() {
+
+        $href = new Href([
+            '/foo/bar',
+            'foo/bar',
+            'http://example.org/bar'
+        ]);
+
+        $html = new HtmlOutputHelper(
+            '/base/',
+            []
+        );
+
+        $expected =
+            '<a href="/foo/bar">/foo/bar</a><br />' .
+            '<a href="/base/foo/bar">/base/foo/bar</a><br />' .
+            '<a href="http://example.org/bar">http://example.org/bar</a>';
+        $this->assertEquals($expected, $href->toHtml($html));
 
     }
 

--- a/tests/Sabre/DAVACL/Xml/Property/CurrentUserPrivilegeSetTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/CurrentUserPrivilegeSetTest.php
@@ -3,7 +3,7 @@
 namespace Sabre\DAVACL\Xml\Property;
 
 use Sabre\DAV;
-use Sabre\DAV\XMLUtil;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\HTTP;
 use Sabre\Xml\Reader;
 
@@ -42,6 +42,7 @@ XML;
     <d:privilege>
         <d:write-properties />
     </d:privilege>
+    <d:ignoreme />
     <d:privilege>
         <d:read />
     </d:privilege>
@@ -62,6 +63,24 @@ XML;
         $reader->xml($xml);
         $result = $reader->parse();
         return $result['value'];
+
+    }
+
+    function testToHtml() {
+
+        $privileges = ['{DAV:}read', '{DAV:}write'];
+
+        $prop = new CurrentUserPrivilegeSet($privileges);
+        $html = new HtmlOutputHelper(
+            '/base/',
+            ['DAV:' => 'd']
+        );
+
+        $expected =
+            '<span title="{DAV:}read">d:read</span>, ' .
+            '<span title="{DAV:}write">d:write</span>';
+
+        $this->assertEquals($expected, $prop->toHtml($html));
 
     }
 

--- a/tests/Sabre/DAVACL/Xml/Property/SupportedPrivilegeSetTest.php
+++ b/tests/Sabre/DAVACL/Xml/Property/SupportedPrivilegeSetTest.php
@@ -4,6 +4,7 @@ namespace Sabre\DAVACL\Xml\Property;
 
 use Sabre\DAV;
 use Sabre\HTTP;
+use Sabre\DAV\Browser\HtmlOutputHelper;
 
 class SupportedPrivilegeSetTest extends \PHPUnit_Framework_TestCase {
 
@@ -80,6 +81,40 @@ class SupportedPrivilegeSetTest extends \PHPUnit_Framework_TestCase {
   </d:supported-privilege>
  </d:supported-privilege>
 </d:supported-privilege-set>', $xml);
+
+    }
+
+    function testToHtml() {
+
+        $prop = new SupportedPrivilegeSet([
+            'privilege' => '{DAV:}all',
+            'abstract'  => true,
+            'aggregates' => [
+                [
+                    'privilege' => '{DAV:}read',
+                ],
+                [
+                    'privilege' => '{DAV:}write',
+                    'description' => 'booh',
+                ],
+            ],
+        ]);
+        $html = new HtmlOutputHelper(
+            '/base/',
+            ['DAV:' => 'd']
+        );
+
+        $expected = <<<HTML
+<ul class="tree"><li><span title="{DAV:}all">d:all</span> <i>(abstract)</i>
+<ul>
+<li><span title="{DAV:}read">d:read</span></li>
+<li><span title="{DAV:}write">d:write</span> booh</li>
+</ul></li>
+</ul>
+
+HTML;
+
+        $this->assertEquals($expected, $prop->toHtml($html));
 
     }
 }


### PR DESCRIPTION
This partially fixes a broken dependency problem on `Sabre\DAV\Browser`
as `Sabre\DAV\Browser` had to be aware of `Sabre\DAVACL` to some degree.

It cleans up the property-output code quite a bit. And we now also have
html output for the `{DAV:}acl` property.

Lastly, this should make it easier to unittest these areas due to much better applied OOP principles.