### PR TITLE
Supporting the callable function

### DIFF
--- a/lib/DAV/Auth/Backend/BasicCallBack.php
+++ b/lib/DAV/Auth/Backend/BasicCallBack.php
@@ -53,7 +53,7 @@ class BasicCallBack extends AbstractBasic {
     protected function validateUserPass($username, $password) {
 
         $cb = $this->callBack;
-        return $cb($username, $password);
+        return call_user_func($cb, $username, $password);
 
     }
 


### PR DESCRIPTION
The current implementation had the following problem

    Fatal error: Call to undefined function \ProductName\CardDAV\BasicAuthCallback::validateUserPass() 
    in ../SabreDAV/vendor/sabre/dav/lib/DAV/Auth/Backend/BasicCallBack.php on line 56

At least while working with the following PHP version: 

    PHP 5.5.9-1ubuntu4.5 (cli) (built: Oct 29 2014 11:59:10) 
    Copyright (c) 1997-2014 The PHP Group
    Zend Engine v2.5.0, Copyright (c) 1998-2014 Zend Technologies
    with Zend OPcache v7.0.3, Copyright (c) 1999-2014, by Zend Technologies


The fix was made according to [PHP Documentation :: Callable](http://php.net/manual/en/language.types.callable.php) 