### PR TITLE
Fix calendar deletion

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -309,7 +309,7 @@ class PDO extends AbstractBackend implements SyncSupport, SubscriptionSupport, S
         $stmt = $this->pdo->prepare('DELETE FROM '.$this->calendarTableName.' WHERE id = ?');
         $stmt->execute([$calendarId]);
 
-        $stmt = $this->pdo->prepare('DELETE FROM '.$this->calendarChangesTableName.' WHERE id = ?');
+        $stmt = $this->pdo->prepare('DELETE FROM '.$this->calendarChangesTableName.' WHERE calendarid = ?');
         $stmt->execute([$calendarId]);
 
     }


### PR DESCRIPTION
Deleting calendar previously didn't deleted every occurrence of the calendar in the Calendar Changes table, but only the one with the id corresponding to the calendarId (even with no link between them)