### PR TITLE
`getChild` works with a class-child of `Directory`

### DIFF
--- a/lib/DAVACL/FS/Collection.php
+++ b/lib/DAVACL/FS/Collection.php
@@ -64,7 +64,7 @@ class Collection extends BaseCollection implements IACL {
 
         if (is_dir($path)) {
 
-            return new self($path, $this->acl, $this->owner);
+            return new static($path, $this->acl, $this->owner);
 
         } else {
 


### PR DESCRIPTION
We simply replace `self` by `static`.

Needed for sabre/katana.