### PR TITLE
Simplify future maintenance

### DIFF
--- a/lib/DAV/FSExt/Directory.php
+++ b/lib/DAV/FSExt/Directory.php
@@ -89,7 +89,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota, DAV\IMoveTa
 
         if (is_dir($path)) {
 
-            return new Directory($path);
+            return new self($path);
 
         } else {
 


### PR DESCRIPTION
By replacing the class name by `self`, we simplify future maintenance.