### PR TITLE
FIX for webdav.mediencenter.t-online.de

### DIFF
--- a/lib/Sabre/DAV/Client.php
+++ b/lib/Sabre/DAV/Client.php
@@ -557,8 +557,15 @@ class Client {
 
                 $propStat->registerXPathNamespace('d', 'urn:DAV');
                 $status = $propStat->xpath('d:status');
-                list($httpVersion, $statusCode, $message) = explode(' ', (string)$status[0],3);
-
+                
+                // This resolves issues that are flooding the log file due to some malformed
+                // WebDAV response e.g. T-Mobile's cloud named "Mediencenter"
+                // This has the positve side-effect of a huge speed inporovement on erros
+                if (count($status) < 1 || empty($status[0]) || count($status) < 3)
+                    $statusCode='200';
+                else
+                    list($httpVersion, $statusCode, $message) = explode(' ', (string)$status[0],3);
+                
                 // Only using the propertymap for results with status 200.
                 $propertyMap = $statusCode==='200' ? $this->propertyMap : array();
 


### PR DESCRIPTION
https://webdav.mediencenter.t-online.de returns invalid response code.

e.g.
{"reqId":"f9a1c394b98108e4e5ca62bf47829c64","remoteAddr":"81.189.45.224","app":"PHP","message":"Undefined offset: 2 at \/var\/www\/owncloud\/3rdparty\/sabre\/dav\/lib\/Sabre\/DAV\/Client.php#569","level":3,"time":"2015-03-25T18:25:48+00:00","method":"GET","url":"\/index.php\/apps\/files\/ajax\/getstoragestats.php?dir=External%2FT-Cloud%2FTests"}

as documented here: https://github.com/owncloud/3rdparty/pull/169