### PR TITLE
Client add support for NTLM auth

### DIFF
--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -51,6 +51,11 @@ class Client extends HTTP\Client {
     const AUTH_DIGEST = 2;
 
     /**
+     * NTLM authentication
+     */
+    const AUTH_NTLM = 4;
+
+    /**
      * Identity encoding, which basically does not nothing.
      */
     const ENCODING_IDENTITY = 1;
@@ -90,8 +95,8 @@ class Client extends HTTP\Client {
      *   * authType (optional)
      *   * encoding (optional)
      *
-     *  authType must be a bitmap, using self::AUTH_BASIC and
-     *  self::AUTH_DIGEST. If you know which authentication method will be
+     *  authType must be a bitmap, using self::AUTH_BASIC, self::AUTH_DIGEST
+     *  and self::AUTH_NTLM. If you know which authentication method will be
      *  used, it's recommended to set it, as it will save a great deal of
      *  requests to 'discover' this information.
      *
@@ -124,6 +129,9 @@ class Client extends HTTP\Client {
                 }
                 if ($settings['authType'] & self::AUTH_DIGEST) {
                     $curlType |= CURLAUTH_DIGEST;
+                }
+                if ($settings['authType'] & self::AUTH_NTLM) {
+                    $curlType |= CURLAUTH_NTLM;
                 }
             } else {
                 $curlType = CURLAUTH_BASIC | CURLAUTH_DIGEST;

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -68,6 +68,19 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
 
     }
 
+    function testNTLMAuth() {
+
+        $client = new ClientMock([
+            'baseUri' => '/',
+            'userName' => 'foo',
+            'password' => 'bar',
+            'authType' => Client::AUTH_NTLM
+        ]);
+
+        $this->assertEquals("foo:bar", $client->curlSettings[CURLOPT_USERPWD]);
+        $this->assertEquals(CURLAUTH_NTLM, $client->curlSettings[CURLOPT_HTTPAUTH]);
+
+    }
 
     function testProxy() {
 


### PR DESCRIPTION
This pull request adds an AUTH_NTLM constant to the DAV client which can be used when talking 
to an windows webdav server. Or is there any specific reason why only basic and digest auth 
is supported at the moment?