### PR TITLE
Properly concatenate $path, even if it's "0"

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -848,7 +848,11 @@ class Server extends EventEmitter {
         foreach ($this->tree->getChildren($path) as $childNode) {
             $subPropFind = clone $propFind;
             $subPropFind->setDepth($newDepth);
-            $subPath = $path ? $path . '/' . $childNode->getName() : $childNode->getName();
+            if ($path !== '') {
+                $subPath = $path . '/' . $childNode->getName();
+            } else {
+                $subPath = $childNode->getName();
+            }
             $subPropFind->setPath($subPath);
 
             $propFindRequests[] = [


### PR DESCRIPTION
Can be reproduced in ownCloud 8.1 / master (https://github.com/owncloud/client/issues/3351#issuecomment-112736279):
1. Create a folder "0"
2. Create a file "0/test.txt"
3. Do a propfind with depth1 on "0"

It will try and retrieve the properties of "0/test.txt".
But the code before this PR was discarding `$path` because `"0"` evaluates to false...

About the fix:
- did not use `empty($path)` because it turns out that `empty("0")` is true...
- did not use `strlen($path) > 0` because `isset($path[0])` is faster performance-wise

I did not find a good place to quickly add a unit test and also had trouble running them (see https://github.com/fruux/sabre-dav/issues/676)
