### PR TITLE
fixing broken CalDAV sync for Windows Phone

### DIFF
--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -492,7 +492,6 @@ class Plugin extends DAV\ServerPlugin {
         $needsJson = $report->contentType === 'application/calendar+json';
 
         $node = $this->server->tree->getNodeForPath($this->server->getRequestUri());
-        $depth = $this->server->getHTTPDepth(0);
 
         // The default result is an empty array
         $result = [];
@@ -517,7 +516,7 @@ class Plugin extends DAV\ServerPlugin {
 
         // The calendarobject was requested directly. In this case we handle
         // this locally.
-        if ($depth == 0 && $node instanceof ICalendarObject) {
+        if ($node instanceof ICalendarObject) {
 
             $requestedCalendarData = true;
             $requestedProperties = $report->properties;
@@ -578,7 +577,7 @@ class Plugin extends DAV\ServerPlugin {
 
         // If we're dealing with a calendar, the calendar itself is responsible
         // for the calendar-query.
-        if ($node instanceof ICalendarObjectContainer && $depth == 1) {
+        if ($node instanceof ICalendarObjectContainer) {
 
             $nodePaths = $node->calendarQuery($report->filters);
 


### PR DESCRIPTION
Checking for depth header and reqeusted object type is sensless. In case of Windows Phone, the depth header and the requested type does not match.

System: owncloud 8.1 with manually updated SabreDAV 2.1.5
Device: Lumia 1520/830

PS: I was wondering why I lost all calendar entries after updating owncloud from 7.0.4 to latest 8.1 release, so I checked complete calendar implementation of ownloud and found the issue by intercepting device communication and set depth header to 1 (was 0) for the calendar sync requst.

Thanks for great DAV implementation and it would be nice when you accept my merge request.

Regards Enno