### PR TITLE
Update to sabre/vobject 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 matrix:
   fast_finish: true
   allow_failures:
-      - php: 7
+      - php: hhvm
 
 env:
   matrix:

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.4.1",
-        "sabre/vobject": ">=3.3.4,<4",
+        "sabre/vobject": "dev-master",
         "sabre/event" : "~2.0",
         "sabre/xml"  : "~1.0",
         "sabre/http" : "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "sabre/vobject": "dev-master",
+        "sabre/vobject": ">=4.0.0-alpha1",
         "sabre/event" : "~2.0",
         "sabre/xml"  : "~1.0",
         "sabre/http" : "~4.0",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4.1",
+        "php": ">=5.5.0",
         "sabre/vobject": "dev-master",
         "sabre/event" : "~2.0",
         "sabre/xml"  : "~1.0",

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -558,11 +558,11 @@ class PDO extends AbstractBackend implements SyncSupport, SubscriptionSupport, S
                     $lastOccurence = $component->DTEND->getDateTime()->getTimeStamp();
                 } elseif (isset($component->DURATION)) {
                     $endDate = clone $component->DTSTART->getDateTime();
-                    $endDate->add(VObject\DateTimeParser::parse($component->DURATION->getValue()));
+                    $endDate = $endDate->add(VObject\DateTimeParser::parse($component->DURATION->getValue()));
                     $lastOccurence = $endDate->getTimeStamp();
                 } elseif (!$component->DTSTART->hasTime()) {
                     $endDate = clone $component->DTSTART->getDateTime();
-                    $endDate->modify('+1 day');
+                    $endDate = $endDate->modify('+1 day');
                     $lastOccurence = $endDate->getTimeStamp();
                 } else {
                     $lastOccurence = $firstOccurence;

--- a/lib/CalDAV/CalendarQueryValidator.php
+++ b/lib/CalDAV/CalendarQueryValidator.php
@@ -59,7 +59,7 @@ class CalendarQueryValidator {
 
         foreach ($filters as $filter) {
 
-            $isDefined = isset($parent->$filter['name']);
+            $isDefined = isset($parent->{$filter['name']});
 
             if ($filter['is-not-defined']) {
 
@@ -75,7 +75,7 @@ class CalendarQueryValidator {
             }
 
             if ($filter['time-range']) {
-                foreach ($parent->$filter['name'] as $subComponent) {
+                foreach ($parent->{$filter['name']} as $subComponent) {
                     if ($this->validateTimeRange($subComponent, $filter['time-range']['start'], $filter['time-range']['end'])) {
                         continue 2;
                     }
@@ -89,7 +89,7 @@ class CalendarQueryValidator {
 
             // If there are sub-filters, we need to find at least one component
             // for which the subfilters hold true.
-            foreach ($parent->$filter['name'] as $subComponent) {
+            foreach ($parent->{$filter['name']} as $subComponent) {
 
                 if (
                     $this->validateCompFilters($subComponent, $filter['comp-filters']) &&
@@ -128,7 +128,7 @@ class CalendarQueryValidator {
 
         foreach ($filters as $filter) {
 
-            $isDefined = isset($parent->$filter['name']);
+            $isDefined = isset($parent->{$filter['name']});
 
             if ($filter['is-not-defined']) {
 
@@ -144,7 +144,7 @@ class CalendarQueryValidator {
             }
 
             if ($filter['time-range']) {
-                foreach ($parent->$filter['name'] as $subComponent) {
+                foreach ($parent->{$filter['name']} as $subComponent) {
                     if ($this->validateTimeRange($subComponent, $filter['time-range']['start'], $filter['time-range']['end'])) {
                         continue 2;
                     }
@@ -158,7 +158,7 @@ class CalendarQueryValidator {
 
             // If there are sub-filters, we need to find at least one property
             // for which the subfilters hold true.
-            foreach ($parent->$filter['name'] as $subComponent) {
+            foreach ($parent->{$filter['name']} as $subComponent) {
 
                 if (
                     $this->validateParamFilters($subComponent, $filter['param-filters']) &&

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -748,12 +748,12 @@ class Plugin extends ServerPlugin {
      *   * 3.7;description
      *
      * @param string $email address
-     * @param \DateTime $start
-     * @param \DateTime $end
+     * @param DateTimeInterface $start
+     * @param DateTimeInterface $end
      * @param VObject\Component $request
      * @return array
      */
-    protected function getFreeBusyForEmail($email, \DateTime $start, \DateTime $end, VObject\Component $request) {
+    protected function getFreeBusyForEmail($email, \DateTimeInterface $start, \DateTimeInterface $end, VObject\Component $request) {
 
         $caldavNS = '{' . self::NS_CALDAV . '}';
 

--- a/tests/Sabre/CalDAV/CalendarQueryValidatorTest.php
+++ b/tests/Sabre/CalDAV/CalendarQueryValidatorTest.php
@@ -54,6 +54,9 @@ ICS;
                     // We need to test something to be valid for phpunit strict
                     // mode.
                     $this->assertTrue(true);
+                } catch (\Throwable $e) {
+                    // PHP7
+                    $this->assertTrue(true);
                 }
                 break;
 

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Sabre\CalDAV;
+
 use Sabre\HTTP;
 use Sabre\VObject;
 
@@ -16,18 +17,18 @@ class ExpandEventsDTSTARTandDTENDTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
 
-    protected $caldavCalendars = array(
-        array(
-            'id' => 1,
-            'name' => 'Calendar',
+    protected $caldavCalendars = [
+        [
+            'id'           => 1,
+            'name'         => 'Calendar',
             'principaluri' => 'principals/user1',
-            'uri' => 'calendar1',
-        )
-    );
+            'uri'          => 'calendar1',
+        ]
+    ];
 
-    protected $caldavCalendarObjects = array(
-        1 => array(
-           'event.ics' => array(
+    protected $caldavCalendarObjects = [
+        1 => [
+           'event.ics' => [
                 'calendardata' => 'BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
@@ -47,17 +48,17 @@ RECURRENCE-ID;TZID=Europe/Berlin:20120208T181500
 END:VEVENT
 END:VCALENDAR
 ',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     function testExpand() {
 
         $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
+            'REQUEST_METHOD'    => 'REPORT',
             'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI' => '/calendars/user1/calendar1',
-            'HTTP_DEPTH' => '1',
+            'REQUEST_URI'       => '/calendars/user1/calendar1',
+            'HTTP_DEPTH'        => '1',
         ]);
 
         $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
@@ -85,30 +86,28 @@ END:VCALENDAR
             $start = strpos($response->body, 'BEGIN:VCALENDAR'),
             strpos($response->body, 'END:VCALENDAR') - $start + 13
         );
-        $body = str_replace('&#13;','',$body);
+        $body = str_replace('&#13;', '', $body);
 
         try {
             $vObject = VObject\Reader::read($body);
         } catch (VObject\ParseException $e) {
-            $this->fail('Could not parse object. Error:' . $e->getMessage(). ' full object: ' . $response->getBodyAsString());
+            $this->fail('Could not parse object. Error:' . $e->getMessage() . ' full object: ' . $response->getBodyAsString());
         }
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
             /** @var $vevent Sabre\VObject\Component\VEvent */
-            foreach ($vevent->children as $child) {
+            foreach ($vevent->children() as $child) {
                 /** @var $child Sabre\VObject\Property */
-
                 if ($child->name == 'DTSTART') {
                     // DTSTART has to be one of three valid values
-                    $this->assertContains($child->getValue(), ['20120207T171500Z', '20120208T171500Z', '20120209T171500Z'], 'DTSTART is not a valid value: '.$child->getValue());
+                    $this->assertContains($child->getValue(), ['20120207T171500Z', '20120208T171500Z', '20120209T171500Z'], 'DTSTART is not a valid value: ' . $child->getValue());
                 } elseif ($child->name == 'DTEND') {
                     // DTEND has to be one of three valid values
-                    $this->assertContains($child->getValue(), ['20120207T181500Z', '20120208T181500Z', '20120209T181500Z'], 'DTEND is not a valid value: '.$child->getValue());
+                    $this->assertContains($child->getValue(), ['20120207T181500Z', '20120208T181500Z', '20120209T181500Z'], 'DTEND is not a valid value: ' . $child->getValue());
                 }
             }
         }
     }
 
 }
-

--- a/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsDTSTARTandDTENDbyDayTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Sabre\CalDAV;
+
 use Sabre\HTTP;
 use Sabre\VObject;
 
@@ -15,18 +16,18 @@ class ExpandEventsDTSTARTandDTENDbyDayTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
 
-    protected $caldavCalendars = array(
-        array(
-            'id' => 1,
-            'name' => 'Calendar',
+    protected $caldavCalendars = [
+        [
+            'id'           => 1,
+            'name'         => 'Calendar',
             'principaluri' => 'principals/user1',
-            'uri' => 'calendar1',
-        )
-    );
+            'uri'          => 'calendar1',
+        ]
+    ];
 
-    protected $caldavCalendarObjects = array(
-        1 => array(
-           'event.ics' => array(
+    protected $caldavCalendarObjects = [
+        1 => [
+           'event.ics' => [
                 'calendardata' => 'BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
@@ -38,18 +39,18 @@ DTSTART;TZID=Europe/Berlin:20120207T181500
 END:VEVENT
 END:VCALENDAR
 ',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     function testExpandRecurringByDayEvent() {
 
-        $request = HTTP\Sapi::createFromServerArray(array(
-            'REQUEST_METHOD' => 'REPORT',
+        $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD'    => 'REPORT',
             'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI' => '/calendars/user1/calendar1',
-            'HTTP_DEPTH' => '1',
-        ));
+            'REQUEST_URI'       => '/calendars/user1/calendar1',
+            'HTTP_DEPTH'        => '1',
+        ]);
 
         $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
@@ -76,7 +77,7 @@ END:VCALENDAR
             $start = strpos($response->body, 'BEGIN:VCALENDAR'),
             strpos($response->body, 'END:VCALENDAR') - $start + 13
         );
-        $body = str_replace('&#13;','',$body);
+        $body = str_replace('&#13;', '', $body);
 
         $vObject = VObject\Reader::read($body);
 
@@ -85,19 +86,17 @@ END:VCALENDAR
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
             /** @var $vevent Sabre\VObject\Component\VEvent */
-            foreach ($vevent->children as $child) {
+            foreach ($vevent->children() as $child) {
                 /** @var $child Sabre\VObject\Property */
-
                 if ($child->name == 'DTSTART') {
                     // DTSTART has to be one of two valid values
-                    $this->assertContains($child->getValue(), array('20120214T171500Z', '20120216T171500Z'), 'DTSTART is not a valid value: '.$child->getValue());
+                    $this->assertContains($child->getValue(), ['20120214T171500Z', '20120216T171500Z'], 'DTSTART is not a valid value: ' . $child->getValue());
                 } elseif ($child->name == 'DTEND') {
                     // DTEND has to be one of two valid values
-                    $this->assertContains($child->getValue(), array('20120214T181500Z', '20120216T181500Z'), 'DTEND is not a valid value: '.$child->getValue());
+                    $this->assertContains($child->getValue(), ['20120214T181500Z', '20120216T181500Z'], 'DTEND is not a valid value: ' . $child->getValue());
                 }
             }
         }
     }
 
 }
-

--- a/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
+++ b/tests/Sabre/CalDAV/ExpandEventsFloatingTimeTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Sabre\CalDAV;
+
 use Sabre\HTTP;
 use Sabre\VObject;
 
@@ -14,12 +15,12 @@ class ExpandEventsFloatingTimeTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAVICSExport = true;
 
-    protected $caldavCalendars = array(
-        array(
-            'id' => 1,
-            'name' => 'Calendar',
-            'principaluri' => 'principals/user1',
-            'uri' => 'calendar1',
+    protected $caldavCalendars = [
+        [
+            'id'                                               => 1,
+            'name'                                             => 'Calendar',
+            'principaluri'                                     => 'principals/user1',
+            'uri'                                              => 'calendar1',
             '{urn:ietf:params:xml:ns:caldav}calendar-timezone' => 'BEGIN:VCALENDAR
 VERSION:2.0
 CALSCALE:GREGORIAN
@@ -41,12 +42,12 @@ TZOFFSETTO:+0100
 END:STANDARD
 END:VTIMEZONE
 END:VCALENDAR',
-        )
-    );
+        ]
+    ];
 
-    protected $caldavCalendarObjects = array(
-        1 => array(
-           'event.ics' => array(
+    protected $caldavCalendarObjects = [
+        1 => [
+           'event.ics' => [
                 'calendardata' => 'BEGIN:VCALENDAR
 VERSION:2.0
 CALSCALE:GREGORIAN
@@ -62,14 +63,14 @@ SEQUENCE:1
 END:VEVENT
 END:VCALENDAR
 ',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     function testExpandCalendarQuery() {
 
         $request = new HTTP\Request('REPORT', '/calendars/user1/calendar1', [
-            'Depth' => 1,
+            'Depth'        => 1,
             'Content-Type' => 'application/xml',
         ]);
 
@@ -98,16 +99,15 @@ END:VCALENDAR
             $start = strpos($response->body, 'BEGIN:VCALENDAR'),
             strpos($response->body, 'END:VCALENDAR') - $start + 13
         );
-        $body = str_replace('&#13;','',$body);
+        $body = str_replace('&#13;', '', $body);
 
         $vObject = VObject\Reader::read($body);
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
             /** @var $vevent Sabre\VObject\Component\VEvent */
-            foreach ($vevent->children as $child) {
+            foreach ($vevent->children() as $child) {
                 /** @var $child Sabre\VObject\Property */
-
                 if ($child->name == 'DTSTART') {
                     // DTSTART should be the UTC equivalent of given floating time
                     $this->assertEquals($child->getValue(), '20141108T043000Z');
@@ -122,7 +122,7 @@ END:VCALENDAR
     function testExpandMultiGet() {
 
         $request = new HTTP\Request('REPORT', '/calendars/user1/calendar1', [
-            'Depth' => 1,
+            'Depth'        => 1,
             'Content-Type' => 'application/xml',
         ]);
 
@@ -147,16 +147,15 @@ END:VCALENDAR
             $start = strpos($response->body, 'BEGIN:VCALENDAR'),
             strpos($response->body, 'END:VCALENDAR') - $start + 13
         );
-        $body = str_replace('&#13;','',$body);
+        $body = str_replace('&#13;', '', $body);
 
         $vObject = VObject\Reader::read($body);
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
             /** @var $vevent Sabre\VObject\Component\VEvent */
-            foreach ($vevent->children as $child) {
+            foreach ($vevent->children() as $child) {
                 /** @var $child Sabre\VObject\Property */
-
                 if ($child->name == 'DTSTART') {
                     // DTSTART should be the UTC equivalent of given floating time
                     $this->assertEquals($child->getValue(), '20141108T043000Z');
@@ -171,7 +170,7 @@ END:VCALENDAR
     function testExpandExport() {
 
         $request = new HTTP\Request('GET', '/calendars/user1/calendar1?export&start=1&end=2000000000&expand=1', [
-            'Depth' => 1,
+            'Depth'        => 1,
             'Content-Type' => 'application/xml',
         ]);
 
@@ -185,16 +184,15 @@ END:VCALENDAR
             $start = strpos($response->body, 'BEGIN:VCALENDAR'),
             strpos($response->body, 'END:VCALENDAR') - $start + 13
         );
-        $body = str_replace('&#13;','',$body);
+        $body = str_replace('&#13;', '', $body);
 
         $vObject = VObject\Reader::read($body);
 
         // check if DTSTARTs and DTENDs are correct
         foreach ($vObject->VEVENT as $vevent) {
             /** @var $vevent Sabre\VObject\Component\VEvent */
-            foreach ($vevent->children as $child) {
+            foreach ($vevent->children() as $child) {
                 /** @var $child Sabre\VObject\Property */
-
                 if ($child->name == 'DTSTART') {
                     // DTSTART should be the UTC equivalent of given floating time
                     $this->assertEquals($child->getValue(), '20141108T043000Z');
@@ -207,4 +205,3 @@ END:VCALENDAR
     }
 
 }
-

--- a/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
+++ b/tests/Sabre/CalDAV/GetEventsByTimerangeTest.php
@@ -1,8 +1,8 @@
 <?php
 
 namespace Sabre\CalDAV;
+
 use Sabre\HTTP;
-use Sabre\VObject;
 
 /**
  * This unittest is created to check if queries for time-range include the start timestamp or not
@@ -15,18 +15,18 @@ class GetEventsByTimerangeTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
 
-    protected $caldavCalendars = array(
-        array(
-            'id' => 1,
-            'name' => 'Calendar',
+    protected $caldavCalendars = [
+        [
+            'id'           => 1,
+            'name'         => 'Calendar',
             'principaluri' => 'principals/user1',
-            'uri' => 'calendar1',
-        )
-    );
+            'uri'          => 'calendar1',
+        ]
+    ];
 
-    protected $caldavCalendarObjects = array(
-        1 => array(
-           'event.ics' => array(
+    protected $caldavCalendarObjects = [
+        1 => [
+           'event.ics' => [
                 'calendardata' => 'BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
@@ -41,17 +41,17 @@ SEQUENCE:4
 END:VEVENT
 END:VCALENDAR
 ',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     function testQueryTimerange() {
 
         $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'REPORT',
+            'REQUEST_METHOD'    => 'REPORT',
             'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI' => '/calendars/user1/calendar1',
-            'HTTP_DEPTH' => '1',
+            'REQUEST_URI'       => '/calendars/user1/calendar1',
+            'HTTP_DEPTH'        => '1',
         ]);
 
         $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
@@ -66,31 +66,15 @@ END:VCALENDAR
         <C:comp-filter name="VCALENDAR">
             <C:comp-filter name="VEVENT">
                 <C:time-range start="20120226T230000Z" end="20120228T225959Z"/>
-            </C:comp-filter>
+           </C:comp-filter>
         </C:comp-filter>
     </C:filter>
 </C:calendar-query>');
 
         $response = $this->request($request);
 
-        if (strpos($response->body, 'BEGIN:VCALENDAR') === false) {
-            $this->fail('Got no events instead of 1. Output: '.$response->body);
-        }
-
-        // Everts super awesome xml parser.
-        $body = substr(
-            $response->body,
-            $start = strpos($response->body, 'BEGIN:VCALENDAR'),
-            strpos($response->body, 'END:VCALENDAR') - $start + 13
-        );
-        $body = str_replace('&#13;','',$body);
-
-        $vObject = VObject\Reader::read($body);
-
-        // We expect 1 event
-        $this->assertEquals(1, count($vObject->VEVENT), 'We got 0 events instead of 1. Output: ' . $body);
+        $this->assertFalse(strpos($response->body, 'BEGIN:VCALENDAR'));
 
     }
 
 }
-

--- a/tests/Sabre/CalDAV/Issue203Test.php
+++ b/tests/Sabre/CalDAV/Issue203Test.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Sabre\CalDAV;
+
 use Sabre\HTTP;
 use Sabre\VObject;
 
@@ -15,18 +16,18 @@ class Issue203Test extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
 
-    protected $caldavCalendars = array(
-        array(
-            'id' => 1,
-            'name' => 'Calendar',
+    protected $caldavCalendars = [
+        [
+            'id'           => 1,
+            'name'         => 'Calendar',
             'principaluri' => 'principals/user1',
-            'uri' => 'calendar1',
-        )
-    );
+            'uri'          => 'calendar1',
+        ]
+    ];
 
-    protected $caldavCalendarObjects = array(
-        1 => array(
-            'event.ics' => array(
+    protected $caldavCalendarObjects = [
+        1 => [
+            'event.ics' => [
                 'calendardata' => 'BEGIN:VCALENDAR
 VERSION:2.0
 BEGIN:VEVENT
@@ -51,18 +52,18 @@ TRANSP:OPAQUE
 END:VEVENT
 END:VCALENDAR
 ',
-            ),
-        ),
-    );
+            ],
+        ],
+    ];
 
     function testIssue203() {
 
-        $request = HTTP\Sapi::createFromServerArray(array(
-            'REQUEST_METHOD' => 'REPORT',
+        $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD'    => 'REPORT',
             'HTTP_CONTENT_TYPE' => 'application/xml',
-            'REQUEST_URI' => '/calendars/user1/calendar1',
-            'HTTP_DEPTH' => '1',
-        ));
+            'REQUEST_URI'       => '/calendars/user1/calendar1',
+            'HTTP_DEPTH'        => '1',
+        ]);
 
         $request->setBody('<?xml version="1.0" encoding="utf-8" ?>
 <C:calendar-query xmlns:D="DAV:" xmlns:C="urn:ietf:params:xml:ns:caldav">
@@ -89,26 +90,26 @@ END:VCALENDAR
             $start = strpos($response->body, 'BEGIN:VCALENDAR'),
             strpos($response->body, 'END:VCALENDAR') - $start + 13
         );
-        $body = str_replace('&#13;','',$body);
+        $body = str_replace('&#13;', '', $body);
 
         $vObject = VObject\Reader::read($body);
 
         $this->assertEquals(2, count($vObject->VEVENT));
 
 
-        $expectedEvents = array(
-            array(
+        $expectedEvents = [
+            [
                 'DTSTART' => '20120326T135200Z',
                 'DTEND'   => '20120326T145200Z',
                 'SUMMARY' => 'original summary',
-            ),
-            array(
+            ],
+            [
                 'DTSTART'       => '20120328T135200Z',
                 'DTEND'         => '20120328T145200Z',
                 'SUMMARY'       => 'overwritten summary',
                 'RECURRENCE-ID' => '20120327T135200Z',
-            )
-        );
+            ]
+        ];
 
         // try to match agains $expectedEvents array
         foreach ($expectedEvents as $expectedEvent) {
@@ -117,10 +118,8 @@ END:VCALENDAR
 
             foreach ($vObject->VEVENT as $vevent) {
                 /** @var $vevent Sabre\VObject\Component\VEvent */
-
-                foreach ($vevent->children as $child) {
+                foreach ($vevent->children() as $child) {
                     /** @var $child Sabre\VObject\Property */
-
                     if (isset($expectedEvent[$child->name])) {
                         if ($expectedEvent[$child->name] != $child->getValue()) {
                             continue 2;
@@ -132,7 +131,7 @@ END:VCALENDAR
                 break;
             }
 
-            $this->assertTrue($matching, 'Did not find the following event in the response: '.var_export($expectedEvent, true));
+            $this->assertTrue($matching, 'Did not find the following event in the response: ' . var_export($expectedEvent, true));
         }
     }
 }

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -301,7 +301,7 @@ ICS;
             '<d:href>mailto:user3.sabredav@sabredav.org</d:href>',
             '<cal:request-status>2.0;Success</cal:request-status>',
             '<cal:request-status>3.7;Could not find principal</cal:request-status>',
-            'FREEBUSY;FBTYPE=BUSY:20110101T120000Z/20110101T130000Z',
+            'FREEBUSY:20110101T120000Z/20110101T130000Z',
         );
 
         foreach($strings as $string) {

--- a/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
+++ b/tests/Sabre/CalDAV/Xml/Request/CalendarQueryReportTest.php
@@ -2,6 +2,8 @@
 
 namespace Sabre\CalDAV\Xml\Request;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Sabre\DAV\Xml\XmlTest;
 
 class CalendarQueryReportTest extends XmlTest {
@@ -114,8 +116,8 @@ XML;
             '{urn:ietf:params:xml:ns:caldav}calendar-data',
         ];
         $calendarQueryReport->expand = [
-            'start' => new \DateTime('2015-01-01 00:00:00', new \DateTimeZone('UTC')),
-            'end'   => new \DateTime('2016-01-01 00:00:00', new \DateTimeZone('UTC')),
+            'start' => new DateTimeImmutable('2015-01-01 00:00:00', new DateTimeZone('UTC')),
+            'end'   => new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC')),
         ];
         $calendarQueryReport->filters = [
             'name'           => 'VCALENDAR',
@@ -179,8 +181,8 @@ XML;
                             'name'           => 'X-PROP3',
                             'is-not-defined' => false,
                             'time-range'     => [
-                                'start' => new \DateTime('2015-01-01 00:00:00', new \DateTimeZone('UTC')),
-                                'end'   => new \DateTime('2016-01-01 00:00:00', new \DateTimeZone('UTC')),
+                                'start' => new DateTimeImmutable('2015-01-01 00:00:00', new DateTimeZone('UTC')),
+                                'end'   => new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC')),
                             ],
                             'text-match'    => null,
                             'param-filters' => [],
@@ -198,8 +200,8 @@ XML;
                         ],
                     ],
                     'time-range' => [
-                        'start' => new \DateTime('2015-01-01 00:00:00', new \DateTimeZone('UTC')),
-                        'end'   => new \DateTime('2016-01-01 00:00:00', new \DateTimeZone('UTC')),
+                        'start' => new DateTimeImmutable('2015-01-01 00:00:00', new DateTimeZone('UTC')),
+                        'end'   => new DateTimeImmutable('2016-01-01 00:00:00', new DateTimeZone('UTC')),
                     ]
                 ],
             ],

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -9,6 +9,14 @@ require_once 'Sabre/DAV/ClientMock.php';
 
 class ClientTest extends \PHPUnit_Framework_TestCase {
 
+    function setUp() {
+
+        if (!function_exists('curl_init')) {
+            $this->markTestSkipped('CURL must be installed to test the client');
+        }
+
+    }
+
     function testConstruct() {
 
         $client = new ClientMock(array(


### PR DESCRIPTION
This PR upgrades sabre/dav to vobject4. vobject 4 requires PHP 5.5, so this means that sabre/dav also drops PHP versions before 5.5.

Before merging this we need to create a 3.0 branch off master in this repository because this is a BC breaking change that will be part of the next major version.