### PR TITLE
litmus locks:20 fix for support negate lock and invalid etag

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1419,8 +1419,10 @@ class Server extends EventEmitter {
 
 
                 if (($tokenValid && $etagValid) ^ $token['negate']) {
-                    // Both were valid, so we can go to the next condition.
-                    continue 2;
+		    // Litmus locks:20 check where we have valid lock with unvalid etag and "not" lock and unvalid etag
+		    if (!($token['token'] == "DAV:no-lock" && $token['negate'] && !$etagValid))
+		       // Both were valid, so we can go to the next condition.
+                       continue 2;
                 }
 
 


### PR DESCRIPTION
When I try to check webdav compliance to litmus 0.13 (http://www.webdav.org/neon/litmus/)
with PDO mysql locks, the locks check 20 return : 
20. fail_complex_cond_put. FAIL (PUT with complex bogus conditional should fail with 412: 204 No Content)
(and test content is updated)

After analysis I understand this is linked to If: header parsing especially with Not token...
My patch propose to add a condition for check this case and validate the test...

I try to find in git history how you can validate this litmus test but it's seems old and not update from long time ago

If you see a mistake on my side, please tell me