### PR TITLE
fix client prop patch should add {DAV:}prop parent node

### DIFF
--- a/lib/DAV/Xml/Request/PropPatch.php
+++ b/lib/DAV/Xml/Request/PropPatch.php
@@ -51,11 +51,15 @@ class PropPatch implements Element {
 
         foreach ($this->properties as $propertyName => $propertyValue) {
 
-            if (is_null($propertyValue)) {
-                $writer->write(['{DAV:}remove' => [$propertyName => $propertyValue]]);
-            } else {
-                $writer->write(['{DAV:}set' => [$propertyName => $propertyValue]]);
-            }
+	  if (is_null($propertyValue)) {
+	    $writer->startElement("{DAV:}remove");
+	    $writer->write(['{DAV:}prop' => [$propertyName => $propertyValue]]);
+	    $writer->endElement();
+	  } else {
+	    $writer->startElement("{DAV:}set");
+	    $writer->write(['{DAV:}prop' => [$propertyName => $propertyValue]]);
+	    $writer->endElement();
+	  }
 
         }
 


### PR DESCRIPTION
After some test, it's seems OOB Sabre WebDav client Propatch method not correctly encapsulate element in XML request (miss '{DAV:}prop') I propose patch with this element