### PR TITLE
When properties appear in propstat with no value, don't call deserializers

### DIFF
--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -161,7 +161,46 @@ class Response implements Element {
      */
     static function xmlDeserialize(Reader $reader) {
 
+        $reader->pushContext();
+
+        $reader->elementMap['{DAV:}propstat'] = 'Sabre\\Xml\\Element\\KeyValue';
+
+        // We are overriding the parser for {DAV:}prop. This deserializer is
+        // almost identical to the one for Sabre\Xml\Element\KeyValue.
+        //
+        // The difference is that if there are any child-elements inside of
+        // {DAV:}prop, that have no value, normally any deserializers are
+        // called. But we don't want this, because a singlular element without
+        // child-elements implies 'no value' in {DAV:}prop, so we want to skip
+        // deserializers and just set null for those.
+        $reader->elementMap['{DAV:}prop'] = function(Reader $reader) {
+
+            if ($reader->isEmptyElement) {
+                $reader->next();
+                return [];
+            }
+            $values = [];
+            $reader->read();
+            do {
+                if ($reader->nodeType === Reader::ELEMENT) {
+                    $clark = $reader->getClark();
+
+                    if ($reader->isEmptyElement) {
+                        $values[$clark] = null;
+                        $reader->next();
+                    } else {
+                        $values[$clark] = $reader->parseCurrentElement()['value'];
+                    }
+                } else {
+                    $reader->read();
+                }
+            } while ($reader->nodeType !== Reader::END_ELEMENT);
+            $reader->read();
+            return $values;
+
+        };
         $elems = $reader->parseInnerTree();
+        $reader->popContext();
 
         $href = null;
         $propertyLists = [];

--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -170,7 +170,7 @@ class Response implements Element {
         //
         // The difference is that if there are any child-elements inside of
         // {DAV:}prop, that have no value, normally any deserializers are
-        // called. But we don't want this, because a singlular element without
+        // called. But we don't want this, because a singular element without
         // child-elements implies 'no value' in {DAV:}prop, so we want to skip
         // deserializers and just set null for those.
         $reader->elementMap['{DAV:}prop'] = function(Reader $reader) {

--- a/lib/DAV/Xml/Service.php
+++ b/lib/DAV/Xml/Service.php
@@ -20,7 +20,6 @@ class Service extends \Sabre\Xml\Service {
     public $elementMap = [
         '{DAV:}multistatus' => 'Sabre\\DAV\\Xml\\Response\\MultiStatus',
         '{DAV:}response'    => 'Sabre\\DAV\\Xml\\Element\\Response',
-        '{DAV:}propstat'    => 'Sabre\\Xml\\Element\\KeyValue',
 
         // Requests
         '{DAV:}propfind'       => 'Sabre\\DAV\\Xml\\Request\\PropFind',

--- a/tests/Sabre/DAV/Xml/Element/ResponseTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ResponseTest.php
@@ -233,7 +233,7 @@ class ResponseTest extends DAV\Xml\XmlTest {
         $result = $this->parse($xml, [
             '{DAV:}response' => 'Sabre\DAV\Xml\Element\Response',
             '{DAV:}foo' => function($reader) {
-                throw new \LogicException('This should never happned');
+                throw new \LogicException('This should never happen');
             },
         ]);
         $this->assertEquals(

--- a/tests/Sabre/DAV/Xml/Element/ResponseTest.php
+++ b/tests/Sabre/DAV/Xml/Element/ResponseTest.php
@@ -179,4 +179,71 @@ class ResponseTest extends DAV\Xml\XmlTest {
 
     }
 
+    function testDeserializeComplexProperty() {
+
+        $xml = '<?xml version="1.0"?>
+<d:response xmlns:d="DAV:">
+  <d:href>/uri</d:href>
+  <d:propstat>
+    <d:prop>
+      <d:foo>hello</d:foo>
+    </d:prop>
+    <d:status>HTTP/1.1 200 OK</d:status>
+  </d:propstat>
+</d:response>
+';
+
+        $result = $this->parse($xml, [
+            '{DAV:}response' => 'Sabre\DAV\Xml\Element\Response',
+            '{DAV:}foo' => function($reader) {
+
+                $reader->next();
+                return 'world';
+            },
+        ]);
+        $this->assertEquals(
+            new Response('/uri', [
+                '200' => [
+                    '{DAV:}foo' => 'world',
+                ]
+            ]),
+            $result['value']
+        );
+
+    }
+
+    /**
+     * In the case of {DAV:}prop, a deserializer should never get called, if
+     * the property element is empty.
+     */
+    function testDeserializeComplexPropertyEmpty() {
+
+        $xml = '<?xml version="1.0"?>
+<d:response xmlns:d="DAV:">
+  <d:href>/uri</d:href>
+  <d:propstat>
+    <d:prop>
+      <d:foo />
+    </d:prop>
+    <d:status>HTTP/1.1 404 Not Found</d:status>
+  </d:propstat>
+</d:response>
+';
+
+        $result = $this->parse($xml, [
+            '{DAV:}response' => 'Sabre\DAV\Xml\Element\Response',
+            '{DAV:}foo' => function($reader) {
+                throw new \LogicException('This should never happned');
+            },
+        ]);
+        $this->assertEquals(
+            new Response('/uri', [
+                '404' => [
+                    '{DAV:}foo' => null
+                ]
+            ]),
+            $result['value']
+        );
+
+    }
 }


### PR DESCRIPTION
Related to #707 #709 

@DominikTo 