### PR TITLE
Added PDOBasic module which allows BASIC HTTP PDO-based authentication

### DIFF
--- a/lib/DAV/Auth/Backend/PDOBasic.php
+++ b/lib/DAV/Auth/Backend/PDOBasic.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Sabre\DAV\Auth\Backend;
+
+/**
+ * This is an authentication backend that uses a database to manage passwords.
+ *
+ * @copyright Copyright (C) 2007-2015 fruux GmbH (https://fruux.com/).
+ * @author Evert Pot (http://evertpot.com/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class PDOBasic extends AbstractBasic {
+
+    /**
+     * Reference to PDO connection
+     *
+     * @var PDO
+     */
+    protected $pdo;
+
+    /**
+     * PDO table name we'll be using
+     *
+     * @var string
+     */
+    public $tableName = 'users';
+
+
+    /**
+     * Creates the backend object.
+     *
+     * If the filename argument is passed in, it will parse out the specified file fist.
+     *
+     * @param PDO $pdo
+     */
+    function __construct(\PDO $pdo) {
+
+        $this->pdo = $pdo;
+
+    }
+
+    protected function validateUserPass($username, $password) {
+
+    $stmt = $this->pdo->prepare('SELECT digesta1 FROM ' . $this->tableName . ' WHERE username = ?');
+    $stmt->execute([$username]);
+    $digest = md5($username.':'.$this->realm.':'.$password);
+    $digest = md5($username.':SabreDAV:'.$password);
+    $stored=$stmt->fetchColumn();
+    return $stored == $digest;
+    }
+}


### PR DESCRIPTION
One of my clients can not perform DIGEST authentication, so I put together this module that will enable BASIC authentication through PDO.  I have enabled both the PDO and this new PDOBasic backends which allows my BASIC-only client to authenticate while still permitting DIGEST authentication.  The order I used from BASIC then DIGEST.