### PR TITLE
Do not prepend / if the basepath is empty

### DIFF
--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -193,7 +193,8 @@ class Tree {
 
         $node = $this->getNodeForPath($path);
         $children = $node->getChildren();
-        $basePath = trim($path,'/') . '/';
+        $basePath = trim($path,'/');
+        $basePath .= $basePath === '' ? '' : '/';
         foreach($children as $child) {
 
             $this->cache[$basePath . $child->getName()] = $child;


### PR DESCRIPTION
Described in https://github.com/owncloud/core/pull/20003#issuecomment-150934856

Basically in the root the basepath is empty. And this childnodes are cached like '/<CHILD>' while they should be cached as '<CHILD>'.

It seems this is also still the case in the current master.