### PR TITLE
Fix errors when running migration with MySQL

### DIFF
--- a/bin/migrateto20.php
+++ b/bin/migrateto20.php
@@ -133,6 +133,7 @@ foreach(['calendar', 'addressbook'] as $itemType) {
                         ");
                         break;
                 }
+                break;
 
             case 'sqlite' :
 
@@ -170,6 +171,7 @@ foreach(['calendar', 'addressbook'] as $itemType) {
 
                         break;
                 }
+                break;
 
         }
         echo "Creation of 2.0 $tableName table is complete\n";
@@ -393,7 +395,7 @@ CREATE TABLE cards (
     uri VARCHAR(200),
     lastmodified INT(11) UNSIGNED,
     etag VARBINARY(32),
-    size INT(11) UNSIGNED NOT NULL,
+    size INT(11) UNSIGNED NOT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
             ");


### PR DESCRIPTION
This fixes two errors that cause the migration to throw an exception and fail.  The first is a case fall-through that causes the SQLite case to be executed as well and the second is a syntax error in a query.