### PR TITLE
Better exceptions for Client::propFind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ ChangeLog
 * Subtle browser improvements.
 * #726: Better error reporting in `Client::propPatch`. We're now throwing
   exceptions.
+* #608: When a HTTP error is triggered during `Client:propFind`, we're now
+  throwing `Sabre\HTTP\ClientHttpException` instead of `Sabre\DAV\Exception`.
+  This new exception contains a LOT more information about the problem.
 * #721: Events are now handled in the correct order for `COPY` requests.
   Before this subtle bugs could appear that could cause data-loss.
 * #747: Now throwing exceptions and setting the HTTP status to 500 in subtle

--- a/lib/DAV/Client.php
+++ b/lib/DAV/Client.php
@@ -228,7 +228,7 @@ class Client extends HTTP\Client {
         $response = $this->send($request);
 
         if ((int)$response->getStatus() >= 400) {
-            throw new Exception('HTTP error: ' . $response->getStatus());
+            throw new \Sabre\HTTP\ClientHttpException($response);
         }
 
         $result = $this->parseMultiStatus($response->getBodyAsString());

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -149,7 +149,7 @@ XML;
     }
 
     /**
-     * @expectedException \Sabre\DAV\Exception
+     * @expectedException \Sabre\HTTP\ClientHttpException
      */
     function testPropFindError() {
 


### PR DESCRIPTION
We're now throwing `Sabre\HTTP\ClientHttpException`.

Fixes #608 