### PR TITLE
Fixing coding style, add tests/config.user.php for custom test databases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ tests/temp
 tests/.sabredav
 tests/cov
 
+# Custom settings for tests
+tests/config.user.php
+
 # ViM
 *.swp
 

--- a/lib/CardDAV/Backend/PDO.php
+++ b/lib/CardDAV/Backend/PDO.php
@@ -151,7 +151,7 @@ class PDO extends AbstractBackend implements SyncSupport {
      * @param string $principalUri
      * @param string $url Just the 'basename' of the url.
      * @param array $properties
-     * @return void
+     * @return int Last insert id
      */
     function createAddressBook($principalUri, $url, array $properties) {
 

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -188,9 +188,10 @@ class Plugin extends DAV\ServerPlugin {
      *
      * @param string $reportName
      * @param \DOMNode $dom
+     * @param mixed $path
      * @return bool
      */
-    function report($reportName, $dom) {
+    function report($reportName, $dom, $path) {
 
         switch ($reportName) {
             case '{' . self::NS_CARDDAV . '}addressbook-multiget' :

--- a/tests/Sabre/CardDAV/AddressBookTest.php
+++ b/tests/Sabre/CardDAV/AddressBookTest.php
@@ -163,7 +163,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
 
     function testGetSyncTokenNoSyncSupport() {
 
-        $this->assertNull(null, $this->ab->getSyncToken());
+        $this->assertNull($this->ab->getSyncToken());
 
     }
     function testGetChangesNoSyncSupport() {
@@ -179,6 +179,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
         }
         $ab = new AddressBook(TestUtil::getBackend(), [ 'id' => 1, '{DAV:}sync-token' => 2]);
         $this->assertEquals(2, $ab->getSyncToken());
+        TestUtil::deleteSQLiteDB();
     }
 
     function testGetSyncToken2() {
@@ -188,6 +189,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
         }
         $ab = new AddressBook(TestUtil::getBackend(), [ 'id' => 1, '{http://sabredav.org/ns}sync-token' => 2]);
         $this->assertEquals(2, $ab->getSyncToken());
+        TestUtil::deleteSQLiteDB();
     }
 
     function testGetChanges() {
@@ -202,6 +204,7 @@ class AddressBookTest extends \PHPUnit_Framework_TestCase {
             'deleted' => [],
             'added' => ['UUID-2345'],
         ], $ab->getChanges(1, 1));
+        TestUtil::deleteSQLiteDB();
 
     }
 

--- a/tests/Sabre/CardDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CardDAV/Backend/AbstractPDOTest.php
@@ -39,7 +39,7 @@ abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
                 '{DAV:}displayname' => 'book1',
                 '{' . CardDAV\Plugin::NS_CARDDAV . '}addressbook-description' => 'addressbook 1',
                 '{http://calendarserver.org/ns/}getctag' => 1,
-                '{http://sabredav.org/ns}sync-token' => "1"
+                '{http://sabredav.org/ns}sync-token' => 1
             )
         );
 

--- a/tests/Sabre/CardDAV/Backend/PDOSqliteTest.php
+++ b/tests/Sabre/CardDAV/Backend/PDOSqliteTest.php
@@ -18,6 +18,15 @@ class PDOSqliteTest extends AbstractPDOTest {
      */
     function getPDO() {
 
+        return self::getSQLite();
+
+    }
+
+    /**
+     * @return PDO
+     */
+    static function getSQLite() {
+
         if (!SABRE_HASSQLITE) $this->markTestSkipped('SQLite driver is not available');
         $pdo = new \PDO('sqlite:'.SABRE_TEMPDIR.'/pdobackend');
         $pdo->setAttribute(\PDO::ATTR_ERRMODE,\PDO::ERRMODE_EXCEPTION);

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -54,7 +54,7 @@ class PluginTest extends AbstractPluginTest {
 
     function testReportPassThrough() {
 
-        $this->assertNull($this->plugin->report('{DAV:}foo', new \DomDocument()));
+        $this->assertNull($this->plugin->report('{DAV:}foo', new \DomDocument(), ''));
 
     }
 

--- a/tests/Sabre/CardDAV/TestUtil.php
+++ b/tests/Sabre/CardDAV/TestUtil.php
@@ -15,17 +15,8 @@ class TestUtil {
 
     static function getSQLiteDB() {
 
-        if (file_exists(SABRE_TEMPDIR . '/testdb.sqlite'))
-            unlink(SABRE_TEMPDIR . '/testdb.sqlite');
+        $pdo = Backend\PDOSqliteTest::getSQLite();
 
-        $pdo = new PDO('sqlite:' . SABRE_TEMPDIR . '/testdb.sqlite');
-        $pdo->setAttribute(PDO::ATTR_ERRMODE,PDO::ERRMODE_EXCEPTION);
-
-        // Yup this is definitely not 'fool proof', but good enough for now.
-        $queries = explode(';', file_get_contents(__DIR__ . '/../../../examples/sql/sqlite.addressbooks.sql'));
-        foreach($queries as $query) {
-            $pdo->exec($query);
-        }
         // Inserting events through a backend class.
         $backend = new Backend\PDO($pdo);
         $addressbookId = $backend->createAddressBook(
@@ -49,7 +40,12 @@ class TestUtil {
 
     }
 
-    static function getTestCardData($type = 1) {
+    static function deleteSQLiteDB() {
+        $sqliteTest = new Backend\PDOSqliteTest();
+        $pdo = $sqliteTest->tearDown();
+    }
+
+    static function getTestCardData() {
 
         $addressbookData = 'BEGIN:VCARD
 VERSION:3.0

--- a/tests/Sabre/DAV/ClientTest.php
+++ b/tests/Sabre/DAV/ClientTest.php
@@ -121,20 +121,20 @@ class ClientTest extends \PHPUnit_Framework_TestCase {
         $responseBody = <<<XML
 <?xml version="1.0"?>
 <multistatus xmlns="DAV:">
-<response>
-  <href>/foo</href>
-  <propstat>
-    <prop>
-      <displayname>bar</displayname>
-    </prop>
-    <status>HTTP/1.1 200 OK</status>
-  </propstat>
-</response>
+  <response>
+    <href>/foo</href>
+    <propstat>
+      <prop>
+        <displayname>bar</displayname>
+      </prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
 </multistatus>
 XML;
 
         $client->response = new Response(207, [], $responseBody);
-        $result = $client->propfind('foo', ['{DAV:}displayname', '{urn:zim}gir']);
+        $result = $client->propFind('foo', ['{DAV:}displayname', '{urn:zim}gir']);
 
         $this->assertEquals(['{DAV:}displayname' => 'bar'], $result);
 
@@ -158,7 +158,7 @@ XML;
         ]);
 
         $client->response = new Response(405, []);
-        $client->propfind('foo', ['{DAV:}displayname', '{urn:zim}gir']);
+        $client->propFind('foo', ['{DAV:}displayname', '{urn:zim}gir']);
 
     }
 
@@ -171,20 +171,20 @@ XML;
         $responseBody = <<<XML
 <?xml version="1.0"?>
 <multistatus xmlns="DAV:">
-<response>
-  <href>/foo</href>
-  <propstat>
-    <prop>
-      <displayname>bar</displayname>
-    </prop>
-    <status>HTTP/1.1 200 OK</status>
-  </propstat>
-</response>
+  <response>
+    <href>/foo</href>
+    <propstat>
+      <prop>
+        <displayname>bar</displayname>
+      </prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
 </multistatus>
 XML;
 
         $client->response = new Response(207, [], $responseBody);
-        $result = $client->propfind('foo', ['{DAV:}displayname', '{urn:zim}gir'], 1);
+        $result = $client->propFind('foo', ['{DAV:}displayname', '{urn:zim}gir'], 1);
 
         $this->assertEquals([
             '/foo' => [
@@ -211,15 +211,15 @@ XML;
         $responseBody = <<<XML
 <?xml version="1.0"?>
 <multistatus xmlns="DAV:">
-<response>
-  <href>/foo</href>
-  <propstat>
-    <prop>
-      <displayname>bar</displayname>
-    </prop>
-    <status>HTTP/1.1 200 OK</status>
-  </propstat>
-</response>
+  <response>
+    <href>/foo</href>
+    <propstat>
+      <prop>
+        <displayname>bar</displayname>
+      </prop>
+      <status>HTTP/1.1 200 OK</status>
+    </propstat>
+  </response>
 </multistatus>
 XML;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -20,6 +20,13 @@ $config = [
     'SABRE_MYSQLPASS' => '',
 ];
 
+if (file_exists(__DIR__ . '/config.user.php')) {
+    include __DIR__ . '/config.user.php';
+    foreach($userConfig as $key=>$value) {
+        $config[$key] = $value;
+    }
+}
+
 foreach($config as $key=>$value) {
     if (!defined($key)) define($key, $value);
 }


### PR DESCRIPTION
Adds the usual style fixes.

I additionally added an option to use a custom database for testing. With the changes you can create the file `tests/config.user.php` with some content like

```php
<?php
$userConfig = [
    'SABRE_MYSQLDSN'  => 'mysql:host=127.0.0.1;dbname=sabredav_test',
    'SABRE_MYSQLUSER' => 'sabredav',
    'SABRE_MYSQLPASS' => 'sabredav',
];
```

to set the test database without adding the environment variables.