### PR TITLE
Various style fixes for CalDav

### DIFF
--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -272,11 +272,11 @@ class ICSExportPlugin extends DAV\ServerPlugin {
     function mergeObjects(array $properties, array $inputObjects) {
 
         $calendar = new VObject\Component\VCalendar();
-        $calendar->version = '2.0';
+        $calendar->VERSION = '2.0';
         if (DAV\Server::$exposeVersion) {
-            $calendar->prodid = '-//SabreDAV//SabreDAV ' . DAV\Version::VERSION . '//EN';
+            $calendar->PRODID = '-//SabreDAV//SabreDAV ' . DAV\Version::VERSION . '//EN';
         } else {
-            $calendar->prodid = '-//SabreDAV//SabreDAV//EN';
+            $calendar->PRODID = '-//SabreDAV//SabreDAV//EN';
         }
         if (isset($properties['{DAV:}displayname'])) {
             $calendar->{'X-WR-CALNAME'} = $properties['{DAV:}displayname'];

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -233,9 +233,10 @@ class Plugin extends DAV\ServerPlugin {
      *
      * @param string $reportName
      * @param mixed $report
+     * @param mixed $path
      * @return bool
      */
-    function report($reportName, $report) {
+    function report($reportName, $report, $path) {
 
         switch ($reportName) {
             case '{' . self::NS_CALDAV . '}calendar-multiget' :

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -727,7 +727,7 @@ class Plugin extends ServerPlugin {
     protected function handleFreeBusyRequest(IOutbox $outbox, VObject\Component $vObject, RequestInterface $request, ResponseInterface $response) {
 
         $vFreeBusy = $vObject->VFREEBUSY;
-        $organizer = $vFreeBusy->organizer;
+        $organizer = $vFreeBusy->ORGANIZER;
 
         $organizer = (string)$organizer;
 

--- a/lib/CalDAV/SharingPlugin.php
+++ b/lib/CalDAV/SharingPlugin.php
@@ -328,7 +328,7 @@ class SharingPlugin extends DAV\ServerPlugin {
                 $response->setHeader('X-Sabre-Status', 'everything-went-well');
 
                 if ($url) {
-                    $writer = $this->server->xml->getWriter($this->server->getBaseUri());
+                    $writer = $this->server->xml->getWriter();
                     $writer->openMemory();
                     $writer->startDocument();
                     $writer->startElement('{' . Plugin::NS_CALENDARSERVER . '}shared-as');

--- a/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
+++ b/tests/Sabre/CalDAV/Backend/AbstractPDOTest.php
@@ -408,7 +408,7 @@ abstract class AbstractPDOTest extends \PHPUnit_Framework_TestCase {
         $object = "BEGIN:VCALENDAR\r\nBEGIN:VEVENT\r\nDTSTART;VALUE=DATE:20120101\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n";
         $backend->createCalendarObject($returnedId, 'random-id', $object);
 
-        $data = $backend->getCalendarObjects($returnedId, 'random-id');
+        $data = $backend->getCalendarObjects($returnedId);
 
         $this->assertEquals(1, count($data));
         $data = $data[0];

--- a/tests/Sabre/CalDAV/Backend/MockSubscriptionSupport.php
+++ b/tests/Sabre/CalDAV/Backend/MockSubscriptionSupport.php
@@ -140,7 +140,6 @@ class MockSubscriptionSupport extends Mock implements SubscriptionSupport {
      */
     function deleteSubscription($subscriptionId) {
 
-        $found = null;
         foreach ($this->subs[$subscriptionId[0]] as $index => $sub) {
 
             if ($sub['id'][1] === $subscriptionId[1]) {

--- a/tests/Sabre/CalDAV/CalendarHomeNotificationsTest.php
+++ b/tests/Sabre/CalDAV/CalendarHomeNotificationsTest.php
@@ -4,8 +4,6 @@ namespace Sabre\CalDAV;
 
 class CalendarHomeNotificationsTest extends \PHPUnit_Framework_TestCase {
 
-    protected $backend;
-
     function testGetChildrenNoSupport() {
 
         $backend = new Backend\Mock();

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -104,7 +104,7 @@ ics;
 XML;
 
         $report = $this->server->xml->parse($reportXML, null, $rootElem);
-        $this->plugin->report($rootElem, $report);
+        $this->plugin->report($rootElem, $report, null);
 
         $this->assertEquals(200, $this->server->httpResponse->status);
         $this->assertEquals('text/calendar', $this->server->httpResponse->getHeader('Content-Type'));
@@ -126,7 +126,6 @@ XML;
 XML;
 
         $report = $this->server->xml->parse($reportXML, null, $rootElem);
-        $this->plugin->report($rootElem, $report);
 
     }
 
@@ -148,7 +147,7 @@ XML;
 XML;
 
         $report = $this->server->xml->parse($reportXML, null, $rootElem);
-        $this->plugin->report($rootElem, $report);
+        $this->plugin->report($rootElem, $report, null);
 
     }
 
@@ -169,7 +168,7 @@ XML;
 XML;
 
         $report = $this->server->xml->parse($reportXML, null, $rootElem);
-        $this->plugin->report($rootElem, $report);
+        $this->plugin->report($rootElem, $report, null);
 
     }
 }

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -200,7 +200,7 @@ class ICSExportPluginTest extends \PHPUnit_Framework_TestCase {
         $s->addPlugin($p);
         $s->addPlugin(new Plugin());
         $s->addPlugin(new DAVACL\Plugin());
-        $s->addPlugin(new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock(), 'SabreDAV'));
+        $s->addPlugin(new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock()));
 
         // Forcing login
         $s->getPlugin('acl')->adminPrincipals = ['principals/admin'];

--- a/tests/Sabre/CalDAV/Notifications/PluginTest.php
+++ b/tests/Sabre/CalDAV/Notifications/PluginTest.php
@@ -51,8 +51,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $this->server->addPlugin(new CalDAV\Plugin());
         // Adding Auth plugin, and ensuring that we are logged in.
         $authBackend = new DAV\Auth\Backend\Mock();
-        $authBackend->defaultUser = 'user1';
-        $authPlugin = new DAV\Auth\Plugin($authBackend, 'SabreDAV');
+        $authPlugin = new DAV\Auth\Plugin($authBackend);
         $this->server->addPlugin($authPlugin);
 
         // This forces a login

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -86,7 +86,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         // Adding Auth plugin, and ensuring that we are logged in.
         $authBackend = new DAV\Auth\Backend\Mock();
         $authBackend->setPrincipal('principals/user1');
-        $authPlugin = new DAV\Auth\Plugin($authBackend, 'SabreDAV');
+        $authPlugin = new DAV\Auth\Plugin($authBackend);
         $authPlugin->beforeMethod(new \Sabre\HTTP\Request(), new \Sabre\HTTP\Response());
         $this->server->addPlugin($authPlugin);
 

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -80,7 +80,7 @@ END:VCALENDAR',
 
         $authBackend = new DAV\Auth\Backend\Mock();
         $authBackend->setPrincipal('principals/user1');
-        $this->authPlugin = new DAV\Auth\Plugin($authBackend, 'SabreDAV');
+        $this->authPlugin = new DAV\Auth\Plugin($authBackend);
         // Forcing authentication to work.
         $this->authPlugin->beforeMethod($this->request, $this->response);
         $this->server->addPlugin($this->authPlugin);

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -289,7 +289,7 @@ RRR;
 
         // If the plugin did not handle this request, it must ensure that the
         // body is still accessible by other plugins.
-        $this->assertEquals($xml, $request->getBody(true));
+        $this->assertEquals($xml, $request->getBody());
 
     }
 

--- a/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarComponentSetTest.php
+++ b/tests/Sabre/CalDAV/Xml/Property/SupportedCalendarComponentSetTest.php
@@ -97,11 +97,6 @@ XML;
             ['{DAV:}root' => 'Sabre\\CalDAV\\Xml\\Property\\SupportedCalendarComponentSet']
         );
 
-        $this->assertEquals(
-            new SupportedCalendarComponentSet([]),
-            $result['value']
-        );
-
     }
 
 }


### PR DESCRIPTION
- remove unneeded variables
- stop tests right after the point where they should fail
- upcase names of VObject magic attributes
- remove unnecessary parameters
- add missing parameters