### PR TITLE
Relative paths won't work on Windows

### DIFF
--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -140,7 +140,7 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
      * @return array
      */
     function getQuotaInfo() {
-        $absolute = getcwd() . '/' . $this->path;
+        $absolute = realpath($this->path);
         return [
             disk_total_space($absolute) - disk_free_space($absolute),
             disk_free_space($absolute)

--- a/lib/DAV/FS/Directory.php
+++ b/lib/DAV/FS/Directory.php
@@ -140,10 +140,10 @@ class Directory extends Node implements DAV\ICollection, DAV\IQuota {
      * @return array
      */
     function getQuotaInfo() {
-
+        $absolute = getcwd() . '/' . $this->path;
         return [
-            disk_total_space($this->path) - disk_free_space($this->path),
-            disk_free_space($this->path)
+            disk_total_space($absolute) - disk_free_space($absolute),
+            disk_free_space($absolute)
         ];
 
     }


### PR DESCRIPTION
Seems that disk_total_space and disk_free_space cannot work with relative paths on Windows (WAMP + PHP 5.6)