### PR TITLE
fixed File::put() phpdoc contract

### DIFF
--- a/lib/DAV/File.php
+++ b/lib/DAV/File.php
@@ -19,7 +19,7 @@ abstract class File extends Node implements IFile {
      *
      * data is a readable stream resource.
      *
-     * @param string|resource $calendarData
+     * @param string|resource $data
      * @return void
      */
     function put($data) {

--- a/lib/DAV/File.php
+++ b/lib/DAV/File.php
@@ -19,7 +19,7 @@ abstract class File extends Node implements IFile {
      *
      * data is a readable stream resource.
      *
-     * @param resource $data
+     * @param string|resource $calendarData
      * @return void
      */
     function put($data) {


### PR DESCRIPTION
subclasses are meant to support both, string and resource.

see impl in https://github.com/fruux/sabre-dav/blob/master/lib/CalDAV/CalendarObject.php#L99