### PR TITLE
Check read privileges for the REPORT and PROPFIND HTTP methods

### DIFF
--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -737,7 +737,9 @@ class Plugin extends DAV\ServerPlugin {
             case 'GET' :
             case 'HEAD' :
             case 'OPTIONS' :
-                // For these 3 we only need to know if the node is readable.
+            case 'REPORT' :
+            case 'PROPFIND' :
+                // For these 5 we only need to know if the node is readable.
                 $this->checkPrivileges($path, '{DAV:}read');
                 break;
 


### PR DESCRIPTION
Hi. Could you please tell me why you don't check privileges for the REPORT and PROPFIND HTTP methods? Because it seems that it is a security issue. I'm using Baikal server (v.0.2.7) to provide ability to sync contacts through the CardDAV protocol. And as I could see someone (consider that he has login `test` and password `576053`) could read foreign address books.
The query to read his own address book (that should work well):
```
curl -v -X REPORT --header "Content-Type: application/xml; charset=utf-8" --header "Depth: 1" \
--header "User-Agent: curl-test-client" --header "Authorization: Basic dGVzdDo1NzYwNTM=" \
--data '<c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav"><d:prop><d:getetag/><c:address-data/></d:prop></c:addressbook-query>' \
http://baikal/card.php/addressbooks/test/default/
```
And the query that should not work but it works somehow:
```
curl -v -X REPORT --header "Content-Type: application/xml; charset=utf-8" --header "Depth: 1" \
--header "User-Agent: curl-test-client" --header "Authorization: Basic dGVzdDo1NzYwNTM=" \
--data '<c:addressbook-query xmlns:d="DAV:" xmlns:c="urn:ietf:params:xml:ns:carddav"><d:prop><d:getetag/><c:address-data/></d:prop></c:addressbook-query>' \
http://baikal/card.php/addressbooks/otheruser/default/
```
If it is a bug I could go ahead and cover this situation with the tests.