### PR TITLE
drop hhvm from travis since underlying sabre-xml doesnt support it ei…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ php:
   - 5.5
   - 5.6
   - 7
-  - hhvm
 
 matrix:
   fast_finish: true
-  allow_failures:
-      - php: hhvm
 
 env:
   matrix:


### PR DESCRIPTION
…ther

as long as sabre-xml does not properly support hhvm we shouldnt test it either.
IMO sabre-dav cannot work on hhvm as long as all the dependencies dont support it.