### PR TITLE
Finaly some sanity in the href stuff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ ChangeLog
   version you now first need to update to sabre/dav 3.1.
 * Removed deprecated function: `Sabre\DAV\Auth\Plugin::getCurrentUser()`.
 * #774: Fixes for getting free disk space on Windows.
+* #801: BC break: If you were using the `Href` object before, it's behavior
+  now changed a bit, and `LocalHref` was added to replace the old, default
+  behavior of `Href`. See the migration doc for more info.
 
 
 3.1.3 (????-??-??)

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -6,7 +6,6 @@ use DateTimeZone;
 use Sabre\DAV;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\MkCol;
-use Sabre\DAV\Xml\Property\Href;
 use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\DAVACL;
 use Sabre\VObject;

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -7,6 +7,7 @@ use Sabre\DAV;
 use Sabre\DAV\Exception\BadRequest;
 use Sabre\DAV\MkCol;
 use Sabre\DAV\Xml\Property\Href;
+use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\DAVACL;
 use Sabre\VObject;
 use Sabre\HTTP;
@@ -342,7 +343,7 @@ class Plugin extends DAV\ServerPlugin {
 
                 $calendarHomePath = $this->getCalendarHomeForPrincipal($principalUrl);
                 if (is_null($calendarHomePath)) return null;
-                return new Href($calendarHomePath . '/');
+                return new LocalHref($calendarHomePath . '/');
 
             });
             // The calendar-user-address-set property is basically mapped to
@@ -350,7 +351,7 @@ class Plugin extends DAV\ServerPlugin {
             $propFind->handle('{' . self::NS_CALDAV . '}calendar-user-address-set', function() use ($node) {
                 $addresses = $node->getAlternateUriSet();
                 $addresses[] = $this->server->getBaseUri() . $node->getPrincipalUrl() . '/';
-                return new Href($addresses, false);
+                return new LocalHref($addresses);
             });
             // For some reason somebody thought it was a good idea to add
             // another one of these properties. We're supporting it too.
@@ -395,8 +396,8 @@ class Plugin extends DAV\ServerPlugin {
 
                 }
 
-                $propFind->set($propRead, new Href($readList));
-                $propFind->set($propWrite, new Href($writeList));
+                $propFind->set($propRead, new LocalHref($readList));
+                $propFind->set($propWrite, new LocalHref($writeList));
 
             }
 

--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -9,6 +9,7 @@ use Sabre\DAV\PropFind;
 use Sabre\DAV\PropPatch;
 use Sabre\DAV\INode;
 use Sabre\DAV\Xml\Property\Href;
+use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject;
@@ -215,7 +216,7 @@ class Plugin extends ServerPlugin {
                 }
                 $outboxPath = $calendarHomePath . '/outbox/';
 
-                return new Href($outboxPath);
+                return new LocalHref($outboxPath);
 
             });
             // schedule-inbox-URL property
@@ -227,7 +228,7 @@ class Plugin extends ServerPlugin {
                 }
                 $inboxPath = $calendarHomePath . '/inbox/';
 
-                return new Href($inboxPath);
+                return new LocalHref($inboxPath);
 
             });
 
@@ -256,7 +257,7 @@ class Plugin extends ServerPlugin {
                     if (!isset($child[200][$sccs]) || in_array('VEVENT', $child[200][$sccs]->getValue())) {
                         // Either there is no supported-calendar-component-set
                         // (which is fine) or we found one that supports VEVENT.
-                        return new Href($child['href']);
+                        return new LocalHref($child['href']);
                     }
                 }
 

--- a/lib/CalDAV/SharingPlugin.php
+++ b/lib/CalDAV/SharingPlugin.php
@@ -4,6 +4,7 @@ namespace Sabre\CalDAV;
 
 use Sabre\DAV;
 use Sabre\DAV\Xml\Property\Href;
+use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 
@@ -127,7 +128,7 @@ class SharingPlugin extends DAV\ServerPlugin {
         if ($node instanceof ISharedCalendar) {
 
             $propFind->handle('{' . Plugin::NS_CALENDARSERVER . '}shared-url', function() use ($node) {
-                return new Href(
+                return new LocalHref(
                     $node->getSharedUrl()
                 );
             });
@@ -332,7 +333,7 @@ class SharingPlugin extends DAV\ServerPlugin {
                     $writer->openMemory();
                     $writer->startDocument();
                     $writer->startElement('{' . Plugin::NS_CALENDARSERVER . '}shared-as');
-                    $writer->write(new Href($url));
+                    $writer->write(new LocalHref($url));
                     $writer->endElement();
                     $response->setHeader('Content-Type', 'application/xml');
                     $response->setBody($writer->outputMemory());

--- a/lib/CalDAV/Subscriptions/Subscription.php
+++ b/lib/CalDAV/Subscriptions/Subscription.php
@@ -154,7 +154,7 @@ class Subscription extends Collection implements ISubscription, IACL {
 
             switch ($prop) {
                 case '{http://calendarserver.org/ns/}source' :
-                    $r[$prop] = new Href($this->subscriptionInfo['source'], false);
+                    $r[$prop] = new Href($this->subscriptionInfo['source']);
                     break;
                 default :
                     if (array_key_exists($prop, $this->subscriptionInfo)) {

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -5,6 +5,7 @@ namespace Sabre\CardDAV;
 use Sabre\DAV;
 use Sabre\DAV\Exception\ReportNotSupported;
 use Sabre\DAV\Xml\Property\Href;
+use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\DAVACL;
 use Sabre\HTTP;
 use Sabre\HTTP\RequestInterface;
@@ -156,11 +157,11 @@ class Plugin extends DAV\ServerPlugin {
             $path = $propFind->getPath();
 
             $propFind->handle('{' . self::NS_CARDDAV . '}addressbook-home-set', function() use ($path) {
-                return new Href($this->getAddressBookHomeForPrincipal($path) . '/');
+                return new LocalHref($this->getAddressBookHomeForPrincipal($path) . '/');
             });
 
             if ($this->directories) $propFind->handle('{' . self::NS_CARDDAV . '}directory-gateway', function() {
-                return new Href($this->directories);
+                return new LocalHref($this->directories);
             });
 
         }

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -4,7 +4,6 @@ namespace Sabre\CardDAV;
 
 use Sabre\DAV;
 use Sabre\DAV\Exception\ReportNotSupported;
-use Sabre\DAV\Xml\Property\Href;
 use Sabre\DAV\Xml\Property\LocalHref;
 use Sabre\DAVACL;
 use Sabre\HTTP;

--- a/lib/DAV/Xml/Property/Href.php
+++ b/lib/DAV/Xml/Property/Href.php
@@ -7,6 +7,7 @@ use Sabre\DAV\Browser\HtmlOutputHelper;
 use Sabre\Xml\Element;
 use Sabre\Xml\Reader;
 use Sabre\Xml\Writer;
+use Sabre\Uri;
 
 /**
  * Href property
@@ -32,13 +33,6 @@ class Href implements Element, HtmlOutput {
     protected $hrefs;
 
     /**
-     * Automatically prefix the url with the server base directory
-     *
-     * @var bool
-     */
-    protected $autoPrefix = true;
-
-    /**
      * Constructor
      *
      * You must either pass a string for a single href, or an array of hrefs.
@@ -47,16 +41,13 @@ class Href implements Element, HtmlOutput {
      * and not relative to the servers base uri.
      *
      * @param string|string[] $href
-     * @param bool $autoPrefix
      */
-    function __construct($hrefs, $autoPrefix = true) {
+    function __construct($hrefs) {
 
         if (is_string($hrefs)) {
             $hrefs = [$hrefs];
         }
         $this->hrefs = $hrefs;
-        $this->autoPrefix = $autoPrefix;
-
 
     }
 
@@ -104,9 +95,7 @@ class Href implements Element, HtmlOutput {
     function xmlSerialize(Writer $writer) {
 
         foreach ($this->getHrefs() as $href) {
-            if ($this->autoPrefix) {
-                $href = $writer->contextUri . \Sabre\HTTP\encodePath($href);
-            }
+            $href = Uri\resolve($writer->contextUri, $href);
             $writer->writeElement('{DAV:}href', $href);
         }
 

--- a/lib/DAV/Xml/Property/LocalHref.php
+++ b/lib/DAV/Xml/Property/LocalHref.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Sabre\DAV\Xml\Property;
+
+use Sabre\HTTP;
+
+/**
+ * LocalHref property
+ *
+ * Like the Href property, this element represents {DAV:}href. The difference
+ * is that this is used stricly for paths on the server. The LocalHref property
+ * will prepare the path so it's a valid URI.
+ *
+ * These two objects behave identically:
+ *    new LocalHref($path)
+ *    new Href(\Sabre\HTTP\encodePath($path))
+ *
+ * LocalPath basically ensures that your spaces are %20, and everything that
+ * needs to be is uri encoded.
+ *
+ * @copyright Copyright (C) fruux GmbH (https://fruux.com/)
+ * @author Evert Pot (http://www.rooftopsolutions.nl/)
+ * @license http://sabre.io/license/ Modified BSD License
+ */
+class LocalHref extends Href {
+
+    /**
+     * Constructor
+     *
+     * You must either pass a string for a single href, or an array of hrefs.
+     *
+     * If auto-prefix is set to false, the hrefs will be treated as absolute
+     * and not relative to the servers base uri.
+     *
+     * @param string|string[] $href
+     */
+    function __construct($hrefs) {
+
+        parent::__construct(array_map(
+            function($href) {
+                return \Sabre\HTTP\encodePath($href);
+            },
+            (array)$hrefs
+        ));
+
+    }
+
+}

--- a/tests/Sabre/DAV/Xml/Property/HrefTest.php
+++ b/tests/Sabre/DAV/Xml/Property/HrefTest.php
@@ -30,35 +30,6 @@ class HrefTest extends XmlTest {
 ', $xml);
 
     }
-    function testSerializeSpace() {
-
-        $href = new Href('path alsopath');
-        $this->assertEquals('path alsopath', $href->getHref());
-
-        $this->contextUri = '/bla/';
-
-        $xml = $this->write(['{DAV:}anything' => $href]);
-
-        $this->assertXmlStringEqualsXmlString(
-'<?xml version="1.0"?>
-<d:anything xmlns:d="DAV:"><d:href>/bla/path%20alsopath</d:href></d:anything>
-', $xml);
-
-    }
-
-    function testSerializeNoPrefix() {
-
-        $href = new Href('path', false);
-        $this->assertEquals('path', $href->getHref());
-
-        $xml = $this->write(['{DAV:}anything' => $href]);
-
-        $this->assertXmlStringEqualsXmlString(
-'<?xml version="1.0"?>
-<d:anything xmlns:d="DAV:"><d:href>path</d:href></d:anything>
-', $xml);
-
-    }
 
     function testUnserialize() {
 

--- a/tests/Sabre/DAV/Xml/Property/LocalHrefTest.php
+++ b/tests/Sabre/DAV/Xml/Property/LocalHrefTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Sabre\DAV\Xml\Property;
+
+use Sabre\DAV;
+use Sabre\DAV\Browser\HtmlOutputHelper;
+use Sabre\DAV\Xml\XmlTest;
+
+class LocalHrefTest extends XmlTest {
+
+    function testConstruct() {
+
+        $href = new LocalHref('path');
+        $this->assertEquals('path', $href->getHref());
+
+    }
+
+    function testSerialize() {
+
+        $href = new LocalHref('path');
+        $this->assertEquals('path', $href->getHref());
+
+        $this->contextUri = '/bla/';
+
+        $xml = $this->write(['{DAV:}anything' => $href]);
+
+        $this->assertXmlStringEqualsXmlString(
+'<?xml version="1.0"?>
+<d:anything xmlns:d="DAV:"><d:href>/bla/path</d:href></d:anything>
+', $xml);
+
+    }
+    function testSerializeSpace() {
+
+        $href = new LocalHref('path alsopath');
+        $this->assertEquals('path%20alsopath', $href->getHref());
+
+        $this->contextUri = '/bla/';
+
+        $xml = $this->write(['{DAV:}anything' => $href]);
+
+        $this->assertXmlStringEqualsXmlString(
+'<?xml version="1.0"?>
+<d:anything xmlns:d="DAV:"><d:href>/bla/path%20alsopath</d:href></d:anything>
+', $xml);
+
+    }
+    function testToHtml() {
+
+        $href = new LocalHref([
+            '/foo/bar',
+            'foo/bar',
+            'http://example.org/bar'
+        ]);
+
+        $html = new HtmlOutputHelper(
+            '/base/',
+            []
+        );
+
+        $expected =
+            '<a href="/foo/bar">/foo/bar</a><br />' .
+            '<a href="/base/foo/bar">/base/foo/bar</a><br />' .
+            '<a href="http://example.org/bar">http://example.org/bar</a>';
+        $this->assertEquals($expected, $href->toHtml($html));
+
+    }
+
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,15 +7,15 @@ $autoLoader = include __DIR__ . '/../vendor/autoload.php';
 // SabreDAV tests auto loading
 $autoLoader->add('Sabre\\', __DIR__);
 // VObject tests auto loading
-$autoLoader->addPsr4('Sabre\\VObject\\',__DIR__ . '/../vendor/sabre/vobject/tests/VObject');
-$autoLoader->addPsr4('Sabre\\Xml\\',__DIR__ . '/../vendor/sabre/xml/tests/Sabre/Xml');
+$autoLoader->addPsr4('Sabre\\VObject\\', __DIR__ . '/../vendor/sabre/vobject/tests/VObject');
+$autoLoader->addPsr4('Sabre\\Xml\\', __DIR__ . '/../vendor/sabre/xml/tests/Sabre/Xml');
 
 date_default_timezone_set('UTC');
 
 $config = [
     'SABRE_TEMPDIR'   => dirname(__FILE__) . '/temp/',
-    'SABRE_HASSQLITE' => in_array('sqlite',PDO::getAvailableDrivers()),
-    'SABRE_HASMYSQL'  => in_array('mysql',PDO::getAvailableDrivers()),
+    'SABRE_HASSQLITE' => in_array('sqlite', PDO::getAvailableDrivers()),
+    'SABRE_HASMYSQL'  => in_array('mysql', PDO::getAvailableDrivers()),
     'SABRE_MYSQLDSN'  => 'mysql:host=127.0.0.1;dbname=sabredav',
     'SABRE_MYSQLUSER' => 'root',
     'SABRE_MYSQLPASS' => '',
@@ -23,12 +23,12 @@ $config = [
 
 if (file_exists(__DIR__ . '/config.user.php')) {
     include __DIR__ . '/config.user.php';
-    foreach($userConfig as $key=>$value) {
+    foreach ($userConfig as $key => $value) {
         $config[$key] = $value;
     }
 }
 
-foreach($config as $key=>$value) {
+foreach ($config as $key => $value) {
     if (!defined($key)) define($key, $value);
 }
 


### PR DESCRIPTION
This change splits up the functionality from `Href` into `Href` and `LocalHref`. `LocalHref` may be used to encode local sabre/dav paths such as:

* `my folder name`

and `Href` can be used to encode any URI or relative URI, such

* `http://example.org/`
* `my%20folder%20name`

Hopefully this will make everything make more sense =)