### PR TITLE
Set a filename with .ics extension when exporting a calendar

### DIFF
--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -170,13 +170,13 @@ class ICSExportPlugin extends DAV\ServerPlugin {
     protected function generateResponse($path, $start, $end, $expand, $componentType, $format, $properties, ResponseInterface $response) {
 
         $calDataProp = '{' . Plugin::NS_CALDAV . '}calendar-data';
+        $calendarNode = $this->server->tree->getNodeForPath($path);
 
         $blobs = [];
         if ($start || $end || $componentType) {
 
             // If there was a start or end filter, we need to enlist
             // calendarQuery for speed.
-            $calendarNode = $this->server->tree->getNodeForPath($path);
             $queryResult = $calendarNode->calendarQuery([
                 'name'         => 'VCALENDAR',
                 'comp-filters' => [
@@ -259,16 +259,11 @@ class ICSExportPlugin extends DAV\ServerPlugin {
                 break;
         }
 
-        $filename = null;
-        if (isset($properties['{DAV:}displayname']) && $properties['{DAV:}displayname'] !== '') {
-            $filename = preg_replace(
-                '/[^a-zA-Z0-9-_ ]/um',
-                '',
-                $properties['{DAV:}displayname']
-            );
-        } else {
-            $filename = 'calendar';
-        }
+        $filename = preg_replace(
+            '/[^a-zA-Z0-9-_ ]/um',
+            '',
+            $calendarNode->getName()
+        );
         $filename .= '-' . date('Y-m-d') . $filenameExtension;
 
         $response->setHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -246,16 +246,29 @@ class ICSExportPlugin extends DAV\ServerPlugin {
             $mergedCalendar = $mergedCalendar->expand($start, $end, $calendarTimeZone);
         }
 
-        $response->setHeader('Content-Type', $format);
+        $filenameExtension = '.ics';
 
         switch ($format) {
             case 'text/calendar' :
                 $mergedCalendar = $mergedCalendar->serialize();
+                $filenameExtension = '.ics';
                 break;
             case 'application/calendar+json' :
                 $mergedCalendar = json_encode($mergedCalendar->jsonSerialize());
+                $filenameExtension = '.json';
                 break;
         }
+
+        $filename = null;
+        if (isset($properties['{DAV:}displayname']) && $properties['{DAV:}displayname'] !== '') {
+            $filename = $properties['{DAV:}displayname'];
+        } else {
+            $filename = 'calendar';
+        }
+        $filename .= '-' . date('Y-m-d') . $filenameExtension;
+
+        $response->setHeader('Content-Disposition', 'attachment; filename="' . $filename . '"');
+        $response->setHeader('Content-Type', $format);
 
         $response->setStatus(200);
         $response->setBody($mergedCalendar);

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -261,7 +261,11 @@ class ICSExportPlugin extends DAV\ServerPlugin {
 
         $filename = null;
         if (isset($properties['{DAV:}displayname']) && $properties['{DAV:}displayname'] !== '') {
-            $filename = $properties['{DAV:}displayname'];
+            $filename = preg_replace(
+                '/[^a-zA-Z0-9-_ ]/um',
+                '',
+                $properties['{DAV:}displayname']
+            );
         } else {
             $filename = 'calendar';
         }

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -330,7 +330,7 @@ ICS
         $response = $this->request($request, 200);
         $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
         $this->assertEquals(
-            'attachment; filename="Hello!-' . date('Y-m-d') . '.ics"',
+            'attachment; filename="Hello-' . date('Y-m-d') . '.ics"',
             $response->getHeader('Content-Disposition')
         );
 
@@ -347,7 +347,33 @@ ICS
         $response = $this->request($request, 200);
         $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
         $this->assertEquals(
-            'attachment; filename="Hello!-' . date('Y-m-d') . '.json"',
+            'attachment; filename="Hello-' . date('Y-m-d') . '.json"',
+            $response->getHeader('Content-Disposition')
+        );
+
+    }
+
+    function testContentDispositionBadChars() {
+
+        $this->caldavBackend->createCalendar(
+            'principals/admin',
+            'UUID-badchars',
+            [
+                '{DAV:}displayname'                         => 'Test Char-acters!"$%_^&*()~#42<>/',
+                '{http://apple.com/ns/ical/}calendar-color' => '#AA0000FF',
+            ]
+        );
+
+        $request = new HTTP\Request(
+            'GET',
+            '/calendars/admin/UUID-badchars?export',
+            ['Accept' => 'application/calendar+json']
+        );
+
+        $response = $this->request($request, 200);
+        $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
+        $this->assertEquals(
+            'attachment; filename="Test Char-acters_42-' . date('Y-m-d') . '.json"',
             $response->getHeader('Content-Disposition')
         );
 

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -319,4 +319,38 @@ ICS
         $response = $this->request($request, 400);
 
     }
+
+    function testContentDisposition() {
+
+        $request = new HTTP\Request(
+            'GET',
+            '/calendars/admin/UUID-123467?export'
+        );
+
+        $response = $this->request($request, 200);
+        $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
+        $this->assertEquals(
+            'attachment; filename="Hello!-' . date('Y-m-d') . '.ics"',
+            $response->getHeader('Content-Disposition')
+        );
+
+    }
+
+    function testContentDispositionJson() {
+
+        $request = new HTTP\Request(
+            'GET',
+            '/calendars/admin/UUID-123467?export',
+            ['Accept' => 'application/calendar+json']
+        );
+
+        $response = $this->request($request, 200);
+        $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
+        $this->assertEquals(
+            'attachment; filename="Hello!-' . date('Y-m-d') . '.json"',
+            $response->getHeader('Content-Disposition')
+        );
+
+    }
+
 }

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -330,7 +330,7 @@ ICS
         $response = $this->request($request, 200);
         $this->assertEquals('text/calendar', $response->getHeader('Content-Type'));
         $this->assertEquals(
-            'attachment; filename="Hello-' . date('Y-m-d') . '.ics"',
+            'attachment; filename="UUID-123467-' . date('Y-m-d') . '.ics"',
             $response->getHeader('Content-Disposition')
         );
 
@@ -347,7 +347,7 @@ ICS
         $response = $this->request($request, 200);
         $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
         $this->assertEquals(
-            'attachment; filename="Hello-' . date('Y-m-d') . '.json"',
+            'attachment; filename="UUID-123467-' . date('Y-m-d') . '.json"',
             $response->getHeader('Content-Disposition')
         );
 
@@ -357,23 +357,23 @@ ICS
 
         $this->caldavBackend->createCalendar(
             'principals/admin',
-            'UUID-badchars',
+            'UUID-b_ad"(ch)ars',
             [
-                '{DAV:}displayname'                         => 'Test Char-acters!"$%_^&*()~#42<>/',
+                '{DAV:}displayname'                         => 'Test bad characters',
                 '{http://apple.com/ns/ical/}calendar-color' => '#AA0000FF',
             ]
         );
 
         $request = new HTTP\Request(
             'GET',
-            '/calendars/admin/UUID-badchars?export',
+            '/calendars/admin/UUID-b_ad"(ch)ars?export',
             ['Accept' => 'application/calendar+json']
         );
 
         $response = $this->request($request, 200);
         $this->assertEquals('application/calendar+json', $response->getHeader('Content-Type'));
         $this->assertEquals(
-            'attachment; filename="Test Char-acters_42-' . date('Y-m-d') . '.json"',
+            'attachment; filename="UUID-b_adchars-' . date('Y-m-d') . '.json"',
             $response->getHeader('Content-Disposition')
         );
 


### PR DESCRIPTION
Format is `<calendar>-YYYY-MM-DD.ics`, or `<calendar>-YYYY-MM-DD.json` if using the jCal export format. I included a date, since typically a calendar export is done as a backup or 'snapshot' of the current calendar, in which it is almost always useful to have the file tagged with the date of creation.

Downstream feature request: owncloud/core#23751