### PR TITLE
Added support for ACL-based unauthenticated access.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ ChangeLog
 * #774: Fixes for getting free disk space on Windows.
 * #803: Major changes in the sharing API. If you were using an old sabre/dav
   sharing api, head to the website for more detailed migration notes.
+* #657: Support for optional auth using `{DAV:}unauthorized` and `{DAV:}all`
+  privileges. This allows you to assign a privilege to a resource, allowing
+  non-authenticated users to access it. For instance, this could allow you
+  to create a public read-only collection.
 * #812 #814: ICS/VCF exporter now includes a more useful filename in its
   `Content-Disposition` header. (@Xenopathic).
 * #801: BC break: If you were using the `Href` object before, it's behavior

--- a/lib/DAV/Auth/Backend/AbstractDigest.php
+++ b/lib/DAV/Auth/Backend/AbstractDigest.php
@@ -156,7 +156,7 @@ abstract class AbstractDigest implements BackendInterface {
         );
         $auth->init();
 
-        $oldStatus = $response->getStatus() ? : 200;
+        $oldStatus = $response->getStatus() ?: 200;
         $auth->requireLogin();
 
         // Preventing the digest utility from modifying the http status code,

--- a/lib/DAV/Auth/Backend/AbstractDigest.php
+++ b/lib/DAV/Auth/Backend/AbstractDigest.php
@@ -155,7 +155,13 @@ abstract class AbstractDigest implements BackendInterface {
             $response
         );
         $auth->init();
+
+        $oldStatus = $response->getStatus() ? : 200;
         $auth->requireLogin();
+
+        // Preventing the digest utility from modifying the http status code,
+        // this should be handled by the main plugin.
+        $response->setStatus($oldStatus);
 
     }
 

--- a/tests/Sabre/CalDAV/ICSExportPluginTest.php
+++ b/tests/Sabre/CalDAV/ICSExportPluginTest.php
@@ -7,9 +7,6 @@ use Sabre\HTTP;
 use Sabre\VObject;
 use Sabre\DAVACL;
 
-require_once 'Sabre/CalDAV/TestUtil.php';
-require_once 'Sabre/HTTP/ResponseMock.php';
-
 class ICSExportPluginTest extends \Sabre\DAVServerTest {
 
     protected $setupCalDAV = true;
@@ -137,8 +134,10 @@ ICS
 
     function testACLIntegrationBlocked() {
 
+        $aclPlugin = new DAVACL\Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
         $this->server->addPlugin(
-            new DAVACL\Plugin()
+            $aclPlugin
         );
 
         $request = new HTTP\Request(
@@ -152,8 +151,10 @@ ICS
 
     function testACLIntegrationNotBlocked() {
 
+        $aclPlugin = new DAVACL\Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
         $this->server->addPlugin(
-            new DAVACL\Plugin()
+            $aclPlugin
         );
         $this->server->addPlugin(
             new Plugin()

--- a/tests/Sabre/CalDAV/Notifications/PluginTest.php
+++ b/tests/Sabre/CalDAV/Notifications/PluginTest.php
@@ -45,7 +45,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
 
         // Adding ACL plugin
-        $this->server->addPlugin(new DAVACL\Plugin());
+        $aclPlugin = new DAVACL\Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
+        $this->server->addPlugin($aclPlugin);
 
         // CalDAV is also required.
         $this->server->addPlugin(new CalDAV\Plugin());

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -81,7 +81,9 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $this->server->addPlugin($this->plugin);
 
         // Adding ACL plugin
-        $this->server->addPlugin(new DAVACL\Plugin());
+        $aclPlugin = new DAVACL\Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
+        $this->server->addPlugin($aclPlugin);
 
         // Adding Auth plugin, and ensuring that we are logged in.
         $authBackend = new DAV\Auth\Backend\Mock();

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -76,6 +76,7 @@ END:VCALENDAR',
         $this->server->httpResponse = $this->response;
 
         $this->aclPlugin = new DAVACL\Plugin();
+        $this->aclPlugin->allowUnauthenticatedAccess = false;
         $this->server->addPlugin($this->aclPlugin);
 
         $authBackend = new DAV\Auth\Backend\Mock();

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -5,8 +5,6 @@ namespace Sabre\DAV\Auth;
 use Sabre\HTTP;
 use Sabre\DAV;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
-
 class PluginTest extends \PHPUnit_Framework_TestCase {
 
     function testInit() {

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -14,6 +14,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
 
         $acl = new Plugin();
         $server = new DAV\Server();
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpAcl($server->httpRequest, $server->httpResponse);
@@ -36,6 +37,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
 <d:acl xmlns:d="DAV:">
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -56,6 +58,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
 <d:acl xmlns:d="DAV:">
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $this->assertFalse($acl->httpACL($server->httpRequest, $server->httpResponse));
@@ -81,6 +84,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -109,6 +113,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -134,6 +139,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -162,6 +168,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -195,6 +202,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -228,6 +236,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -261,6 +270,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
         $acl->httpACL($server->httpRequest, $server->httpResponse);
@@ -304,6 +314,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
     </d:ace>
 </d:acl>';
         $server->httpRequest->setBody($body);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin($acl);
 
 

--- a/tests/Sabre/DAVACL/AllowAccessTest.php
+++ b/tests/Sabre/DAVACL/AllowAccessTest.php
@@ -20,8 +20,17 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $this->server = new DAV\Server($nodes);
+        $this->server->addPlugin(
+            new DAV\Auth\Plugin(
+                new DAV\Auth\Backend\Mock()
+            )
+        );
+        // Login
+        $this->server->getPlugin('auth')->beforeMethod(
+            new \Sabre\HTTP\Request(),
+            new \Sabre\HTTP\Response()
+        );
         $aclPlugin = new Plugin();
-        $aclPlugin->allowAccessToNodesWithoutACL = true;
         $this->server->addPlugin($aclPlugin);
 
     }

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -21,6 +21,16 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server = new DAV\Server($nodes);
         $this->plugin = new Plugin();
         $this->plugin->setDefaultAcl([]);
+        $this->server->addPlugin(
+            new DAV\Auth\Plugin(
+                new DAV\Auth\Backend\Mock()
+            )
+        );
+        // Login
+        $this->server->getPlugin('auth')->beforeMethod(
+            new \Sabre\HTTP\Request(),
+            new \Sabre\HTTP\Response()
+        );
         $this->server->addPlugin($this->plugin);
 
     }

--- a/tests/Sabre/DAVACL/ExpandPropertiesTest.php
+++ b/tests/Sabre/DAVACL/ExpandPropertiesTest.php
@@ -33,9 +33,9 @@ class ExpandPropertiesTest extends \PHPUnit_Framework_TestCase {
         $fakeServer->debugExceptions = true;
         $fakeServer->httpResponse = new HTTP\ResponseMock();
         $plugin = new Plugin();
-        $plugin->allowAccessToNodesWithoutACL = true;
-
+        $plugin->allowUnauthenticatedAccess = false;
         $this->assertTrue($plugin instanceof Plugin);
+
         $fakeServer->addPlugin($plugin);
         $this->assertEquals($plugin, $fakeServer->getPlugin('acl'));
 

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -10,6 +10,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testPrincipalCollectionSet() {
 
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $plugin->principalCollectionSet = [
             'principals1',
             'principals2',
@@ -78,6 +79,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testSupportedPrivilegeSet() {
 
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $server = new DAV\Server();
         $server->addPlugin($plugin);
 
@@ -137,6 +139,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testACL() {
 
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
 
         $nodes = [
             new MockACLNode('foo', [
@@ -175,6 +178,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
     function testACLRestrictions() {
 
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
 
         $nodes = [
             new MockACLNode('foo', [
@@ -222,6 +226,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         //$plugin = new DAV\Auth\Plugin(new DAV\Auth\MockBackend())
         //$fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);
 
         $requestedProperties = [
@@ -250,6 +255,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         //$plugin = new DAV\Auth\Plugin(new DAV\Auth\MockBackend());
         //$fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);
 
         $requestedProperties = [
@@ -279,6 +285,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         //$plugin = new DAV\Auth\Plugin(new DAV\Auth\MockBackend());
         //$fakeServer->addPlugin($plugin);
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);
 
         $requestedProperties = [
@@ -306,6 +313,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
 
         $fakeServer = new DAV\Server($tree);
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);
 
         $requestedProperties = [
@@ -333,6 +341,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
 
         $fakeServer = new DAV\Server($tree);
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $fakeServer->addPlugin($plugin);
 
         $requestedProperties = [

--- a/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginUpdatePropertiesTest.php
@@ -4,8 +4,6 @@ namespace Sabre\DAVACL;
 
 use Sabre\DAV;
 
-require_once 'Sabre/DAVACL/MockPrincipal.php';
-
 class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
 
     function testUpdatePropertiesPassthrough() {
@@ -14,6 +12,7 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
             new DAV\SimpleCollection('foo'),
         ];
         $server = new DAV\Server($tree);
+        $server->addPlugin(new DAV\Auth\Plugin());
         $server->addPlugin(new Plugin());
 
         $result = $server->updateProperties('foo', [
@@ -34,7 +33,9 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
             new MockPrincipal('foo', 'foo'),
         ];
         $server = new DAV\Server($tree);
-        $server->addPlugin(new Plugin());
+        $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
+        $server->addPlugin($plugin);
 
         $result = $server->updateProperties('foo', [
             '{DAV:}group-member-set' => null,
@@ -55,7 +56,9 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
             new MockPrincipal('foo', 'foo'),
         ];
         $server = new DAV\Server($tree);
-        $server->addPlugin(new Plugin());
+        $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
+        $server->addPlugin($plugin);
 
         $result = $server->updateProperties('foo', [
             '{DAV:}group-member-set' => new DAV\Xml\Property\Href(['/bar', '/baz'], true),
@@ -79,7 +82,9 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
             new MockPrincipal('foo', 'foo'),
         ];
         $server = new DAV\Server($tree);
-        $server->addPlugin(new Plugin());
+        $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
+        $server->addPlugin($plugin);
 
         $result = $server->updateProperties('foo', [
             '{DAV:}group-member-set' => new \StdClass(),
@@ -93,7 +98,9 @@ class PluginUpdatePropertiesTest extends \PHPUnit_Framework_TestCase {
             new DAV\SimpleCollection('foo'),
         ];
         $server = new DAV\Server($tree);
-        $server->addPlugin(new Plugin());
+        $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
+        $server->addPlugin($plugin);
 
         $result = $server->updateProperties('foo', [
             '{DAV:}group-member-set' => new DAV\Xml\Property\Href(['/bar', '/baz'], false),

--- a/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
+++ b/tests/Sabre/DAVACL/PrincipalPropertySearchTest.php
@@ -23,6 +23,7 @@ class PrincipalPropertySearchTest extends \PHPUnit_Framework_TestCase {
         $fakeServer->debugExceptions = true;
         $plugin = new MockPlugin();
         $plugin->allowAccessToNodesWithoutACL = true;
+        $plugin->allowUnauthenticatedAccess = false;
 
         $this->assertTrue($plugin instanceof Plugin);
         $fakeServer->addPlugin($plugin);

--- a/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
+++ b/tests/Sabre/DAVACL/PrincipalSearchPropertySetTest.php
@@ -21,6 +21,7 @@ class PrincipalSearchPropertySetTest extends \PHPUnit_Framework_TestCase {
         $fakeServer->sapi = new HTTP\SapiMock();
         $fakeServer->httpResponse = new HTTP\ResponseMock();
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $this->assertTrue($plugin instanceof Plugin);
         $fakeServer->addPlugin($plugin);
         $this->assertEquals($plugin, $fakeServer->getPlugin('acl'));

--- a/tests/Sabre/DAVACL/SimplePluginTest.php
+++ b/tests/Sabre/DAVACL/SimplePluginTest.php
@@ -115,6 +115,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $plugin = new Plugin();
+        $plugin->allowUnauthenticatedAccess = false;
         $server = new DAV\Server();
         $server->addPlugin($plugin);
         $this->assertEquals($expected, $plugin->getFlatPrivilegeSet(''));
@@ -124,6 +125,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
     function testCurrentUserPrincipalsNotLoggedIn() {
 
         $acl = new Plugin();
+        $acl->allowUnauthenticatedAccess = false;
         $server = new DAV\Server();
         $server->addPlugin($acl);
 
@@ -142,6 +144,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $acl = new Plugin();
+        $acl->allowUnauthenticatedAccess = false;
         $server = new DAV\Server($tree);
         $server->addPlugin($acl);
 
@@ -169,6 +172,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         ];
 
         $acl = new Plugin();
+        $acl->allowUnauthenticatedAccess = false;
         $server = new DAV\Server($tree);
         $server->addPlugin($acl);
 
@@ -212,6 +216,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $server = new DAV\Server($tree);
         $aclPlugin = new Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($aclPlugin);
 
         $this->assertEquals($acl, $aclPlugin->getACL('foo'));
@@ -247,6 +252,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $server = new DAV\Server($tree);
         $aclPlugin = new Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($aclPlugin);
 
         $auth = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());
@@ -299,6 +305,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
 
         $server = new DAV\Server($tree);
         $aclPlugin = new Plugin();
+        $aclPlugin->allowUnauthenticatedAccess = false;
         $server->addPlugin($aclPlugin);
 
         $auth = new DAV\Auth\Plugin(new DAV\Auth\Backend\Mock());

--- a/tests/Sabre/DAVServerTest.php
+++ b/tests/Sabre/DAVServerTest.php
@@ -150,11 +150,6 @@ abstract class DAVServerTest extends \PHPUnit_Framework_TestCase {
             $this->carddavPlugin = new CardDAV\Plugin();
             $this->server->addPlugin($this->carddavPlugin);
         }
-        if ($this->setupACL) {
-            $this->aclPlugin = new DAVACL\Plugin();
-            $this->aclPlugin->adminPrincipals = ['principals/admin'];
-            $this->server->addPlugin($this->aclPlugin);
-        }
         if ($this->setupLocks) {
             $this->locksPlugin = new DAV\Locks\Plugin(
                 $this->locksBackend
@@ -169,6 +164,14 @@ abstract class DAVServerTest extends \PHPUnit_Framework_TestCase {
         }
         if ($this->autoLogin) {
             $this->autoLogin($this->autoLogin);
+        }
+        if ($this->setupACL) {
+            $this->aclPlugin = new DAVACL\Plugin();
+            if (!$this->autoLogin) {
+                $this->aclPlugin->allowUnauthenticatedAccess = false;
+            }
+            $this->aclPlugin->adminPrincipals = ['principals/admin'];
+            $this->server->addPlugin($this->aclPlugin);
         }
 
     }


### PR DESCRIPTION
This PR adds support for `{DAV:}unauthorized` in ACE rules.

The implication is that privileges can be assigned to users that are not currently logged in. This PR works by temporarily turning off the authentication plugin, and only force a user to authenticate if they are attempting to perform an operation they don't have access to.

Fixes #657.