### PR TITLE
Calendar Objects records firstOccurence and lastOccurrence can't save…

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -688,8 +688,8 @@ SQL
             }
             
             // Ensure Occurence values are positive
-            if($firstOccurence<0) $firstOccurence=0;
-            if($lastOccurence<0) $lastOccurence=0;
+            if($firstOccurence < 0) $firstOccurence = 0;
+            if($lastOccurence < 0) $lastOccurence = 0;
         }
 
         // Destroy circular references to PHP will GC the object.

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -686,6 +686,10 @@ SQL
                 }
 
             }
+            
+            // Ensure Occurence values are positive
+            if($firstOccurence<0) $firstOccurence=0;
+            if($lastOccurence<0) $lastOccurence=0;
         }
 
         // Destroy circular references to PHP will GC the object.

--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -688,8 +688,8 @@ SQL
             }
             
             // Ensure Occurence values are positive
-            if($firstOccurence < 0) $firstOccurence = 0;
-            if($lastOccurence < 0) $lastOccurence = 0;
+            if ($firstOccurence < 0) $firstOccurence = 0;
+            if ($lastOccurence < 0) $lastOccurence = 0;
         }
 
         // Destroy circular references to PHP will GC the object.


### PR DESCRIPTION
… dates before Unix epoch (negative values)

When a client wants to sync dates before 1-1-1970 (for example birthdays), the server response with:

```
<?xml version="1.0" encoding="utf-8"?>
<d:error xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns">
  <s:sabredav-version>3.1.2</s:sabredav-version>
  <s:exception>PDOException</s:exception>
  <s:message>SQLSTATE[22003]: Numeric value out of range: 1264 Out of range value for column 'firstoccurence' at row 1</s:message>
</d:error>
```

Dates before 1-1-1970 are represented by negative values that can't be stored in database (the type of these records are unsigned int)

Previous discussion here: https://github.com/fruux/Baikal/pull/537