### PR TITLE
Handle 404 with no PROPSTAT

### DIFF
--- a/lib/DAV/Xml/Element/Response.php
+++ b/lib/DAV/Xml/Element/Response.php
@@ -148,10 +148,12 @@ class Response implements Element {
              * In those cases we MUST specify at least one DAV:propstat anyway, with
              * no properties.
              */
-            $writer->writeElement('{DAV:}propstat', [
-                '{DAV:}prop'   => [],
-                '{DAV:}status' => 'HTTP/1.1 418 ' . \Sabre\HTTP\Response::$statusCodes[418]
-            ]);
+            if ($status != 404) { 
+                $writer->writeElement('{DAV:}propstat', [
+                    '{DAV:}prop'   => [],
+                    '{DAV:}status' => 'HTTP/1.1 418 ' . \Sabre\HTTP\Response::$statusCodes[418]
+                ]);
+            }
 
         }
 


### PR DESCRIPTION
When i delete a contact on addressbook server, the action doesn't appear on Thunderbird with plugin Sogo.
Here are the comments in the source code of Sogo : 
/* 404 responses are now supposed to occur only when no propfind is present. Yet, the "status" seems not mandatory so we play it safe here. */
So, the 404 response with PROPSTAT was not considered.