### PR TITLE
Avoid getting 'too many variables' error with SQLite3 backend

### DIFF
--- a/lib/CalDAV/Backend/PDO.php
+++ b/lib/CalDAV/Backend/PDO.php
@@ -512,7 +512,7 @@ SQL
         list($calendarId, $instanceId) = $calendarId;
 
         $result = [];
-        foreach(array_chunk($uris, 900) as $chunk) {
+        foreach (array_chunk($uris, 900) as $chunk) {
             $query = 'SELECT id, uri, lastmodified, etag, calendarid, size, calendardata, componenttype FROM ' . $this->calendarObjectTableName . ' WHERE calendarid = ? AND uri IN (';
             // Inserting a whole bunch of question marks
             $query .= implode(',', array_fill(0, count($chunk), '?'));


### PR DESCRIPTION
On a growing calendar the REPORT request gets an ever increasing list of URIs with some clients.
The current implemention will break when using SQLite3 as storage backend as it will eventually hit the build in limit for placeholders.

This simple workaround should fix that.