### PR TITLE
Optimize memory usage

### DIFF
--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -333,7 +333,7 @@ class CorePlugin extends ServerPlugin {
         // The only two options for the depth of a propfind is 0 or 1 - as long as depth infinity is not enabled
         if (!$this->server->enablePropfindDepthInfinity && $depth != 0) $depth = 1;
 
-        $newProperties = $this->server->getPropertiesForPath($path, $propFindXml->properties, $depth);
+        $newProperties = $this->server->getPropertiesGeneratorForPath($path, $propFindXml->properties, $depth);
 
         // This is a multi-status response
         $response->setStatus(207);

--- a/lib/DAV/CorePlugin.php
+++ b/lib/DAV/CorePlugin.php
@@ -333,7 +333,7 @@ class CorePlugin extends ServerPlugin {
         // The only two options for the depth of a propfind is 0 or 1 - as long as depth infinity is not enabled
         if (!$this->server->enablePropfindDepthInfinity && $depth != 0) $depth = 1;
 
-        $newProperties = $this->server->getPropertiesGeneratorForPath($path, $propFindXml->properties, $depth);
+        $newProperties = $this->server->getPropertiesIteratorForPath($path, $propFindXml->properties, $depth);
 
         // This is a multi-status response
         $response->setStatus(207);

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -880,9 +880,9 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      *
      * @param PropFind $propFind
      * @param array $yieldFirst
-     * @return \Generator
+     * @return \Iterator
      */
-    private function generatePathNodesRecursively(PropFind $propFind, array $yieldFirst = null) {
+    private function generatePathNodes(PropFind $propFind, array $yieldFirst = null) {
         if ($yieldFirst !== null) {
             yield $yieldFirst;
         }
@@ -909,7 +909,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
             ];
 
             if (($newDepth === self::DEPTH_INFINITY || $newDepth >= 1) && $childNode instanceof ICollection) {
-                foreach ($this->generatePathNodesRecursively($subPropFind) as $subItem) {
+                foreach ($this->generatePathNodes($subPropFind) as $subItem) {
                     yield $subItem;
                 }
             }
@@ -933,7 +933,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      */
     function getPropertiesForPath($path, $propertyNames = [], $depth = 0) {
 
-        return iterator_to_array($this->getPropertiesGeneratorForPath($path, $propertyNames, $depth));
+        return iterator_to_array($this->getPropertiesIteratorForPath($path, $propertyNames, $depth));
 
     }
     /**
@@ -948,9 +948,9 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      * @param string $path
      * @param array $propertyNames
      * @param int $depth
-     * @return \Generator
+     * @return \Iterator
      */
-    function getPropertiesGeneratorForPath($path, $propertyNames = [], $depth = 0) {
+    function getPropertiesIteratorForPath($path, $propertyNames = [], $depth = 0) {
 
         // The only two options for the depth of a propfind is 0 or 1 - as long as depth infinity is not enabled
         if (!$this->enablePropfindDepthInfinity && $depth != 0) $depth = 1;
@@ -968,7 +968,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
         ]];
 
         if (($depth > 0 || $depth === self::DEPTH_INFINITY) && $parentNode instanceof ICollection) {
-            $propFindRequests = $this->generatePathNodesRecursively(clone $propFind, current($propFindRequests));
+            $propFindRequests = $this->generatePathNodes(clone $propFind, current($propFindRequests));
         }
 
         foreach ($propFindRequests as $propFindRequest) {
@@ -1646,7 +1646,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      *
      * If 'strip404s' is set to true, all 404 responses will be removed.
      *
-     * @param array|\Generator $fileProperties The list with nodes
+     * @param array|\Traversable $fileProperties The list with nodes
      * @param bool $strip404s
      * @return string
      */

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -1646,7 +1646,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      *
      * If 'strip404s' is set to true, all 404 responses will be removed.
      *
-     * @param array $fileProperties The list with nodes
+     * @param array|\Generator $fileProperties The list with nodes
      * @param bool $strip404s
      * @return string
      */

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -930,6 +930,9 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      * @param array $propertyNames
      * @param int $depth
      * @return array
+     *
+     * @deprecated Use getPropertiesIteratorForPath() instead (as it's more memory efficient)
+     * @see getPropertiesIteratorForPath()
      */
     function getPropertiesForPath($path, $propertyNames = [], $depth = 0) {
 


### PR DESCRIPTION
Hi!

Our company is currently running WebDAV server in production - which is powered by `sabre/dav`.

In general it works for us, however we need to be able to list directories with tens of thousands of files while having strict memory limits.

Current upstream implementation prepares all the results ("properties") into an array and then generates XML response, so memory requirements grow linearly with count of files in a directory, which doesn't really scale well. While 1000 files in a directory uses 17.3MB (peak memory usage) when listing, 50000 files uses 338 MB.

I wanted to open a discussion about this problem to discuss possible solutions.

In this PR, I implemented it ~~very simple proof of concept~~ using [Generators](http://php.net/manual/en/language.generators.php), which **reduces peak memory usage from aforementioned 338MB to 46.6MB when listing a directory with 50000 files**.

I was wondering if somebody else has come across this issue and if the repo owners or community is interested in memory optimization.

Any feedback appreciated.

Notes:
- ~~this PR is proof of concept to demonstrate how memory usage could be reduced~~
- ~tests will fail, because `Server::getPropertiesForPath()` now returns a `Generator` rather than an array; this functionality could be non-default - i.e. flip some switch (e.g. by a call of new method `Server::useGeneratorsForPropFind(true)`, which would make it non-breaking change)~~
- ~~proposed implementation optimizes only listings with depth 1~~