### PR TITLE
Optimize memory usage: implement "ArrayCache" and limit cache size

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "autoload": {
         "psr-4" : {
+            "Sabre\\Common\\"  : "lib/Common/",
             "Sabre\\DAV\\"     : "lib/DAV/",
             "Sabre\\DAVACL\\"  : "lib/DAVACL/",
             "Sabre\\CalDAV\\"  : "lib/CalDAV/",

--- a/lib/Common/ArrayCache.php
+++ b/lib/Common/ArrayCache.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Sabre\Common;
+
+use ArrayIterator;
+
+/**
+ * Implementation of Cache interface using a simple associative array.
+ */
+class ArrayCache implements Cache {
+
+    const DEFAULT_CACHE_SIZE = 1000;
+
+    /** @var int Maximum count of items in the cache */
+    private $cacheSize;
+
+    /** @var mixed[] */
+    private $cache = [];
+
+    /**
+     * @param int $cacheSize
+     */
+    function __construct($cacheSize = self::DEFAULT_CACHE_SIZE) {
+
+        $this->cacheSize = $cacheSize;
+
+    }
+
+    /**
+     * Retrieves an item from the cache.
+     *
+     * @param string $key
+     * @return mixed|null
+     */
+    function get($key) {
+
+        return array_key_exists($key, $this->cache) ? $this->cache[$key] : null;
+
+    }
+
+    /**
+     * Saves an item to the cache.
+     *
+     * When the capacity is reached, no new items will be added. Existing items under will still get updated even if
+     * the capacity is reached.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    function set($key, $value) {
+
+        $addingNewItem = !array_key_exists($key, $this->cache);
+        if ($addingNewItem && count($this->cache) >= $this->cacheSize) {
+            // don't store new values, if the cache is full
+            return;
+        }
+        $this->cache[$key] = $value;
+
+    }
+
+    /**
+     * Removes an item from the cache.
+     *
+     * @param string $key
+     * @return void
+     */
+    function remove($key) {
+
+        unset($this->cache[$key]);
+
+    }
+
+    /**
+     * Checks whether an item is in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
+    function keyExists($key) {
+
+        return array_key_exists($key, $this->cache);
+
+    }
+
+    /**
+     * Returns all items in the cache (key-value pairs).
+     *
+     * @return \Traversable
+     */
+    function getAll() {
+
+        return new ArrayIterator($this->cache);
+
+    }
+
+}

--- a/lib/Common/Cache.php
+++ b/lib/Common/Cache.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Sabre\Common;
+
+/**
+ * Interface for a general purpose cache.
+ */
+interface Cache {
+
+    /**
+     * Retrieves an item from the cache.
+     *
+     * @param string $key
+     * @return mixed|null
+     */
+    function get($key);
+
+    /**
+     * Saves an item to the cache.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return void
+     */
+    function set($key, $value);
+
+    /**
+     * Removes an item from the cache.
+     *
+     * @param string $key
+     * @return void
+     */
+    function remove($key);
+
+    /**
+     * Checks whether an item is in the cache.
+     *
+     * @param string $key
+     * @return bool
+     */
+    function keyExists($key);
+
+    /**
+     * Returns all items in the cache (key-value pairs).
+     *
+     * @return \Traversable
+     */
+    function getAll();
+
+}

--- a/tests/Sabre/Common/ArrayCacheTest.php
+++ b/tests/Sabre/Common/ArrayCacheTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Sabre\Common;
+
+use PHPUnit_Framework_TestCase;
+
+class ArrayCacheTest extends PHPUnit_Framework_TestCase {
+
+    function testSetGet() {
+
+        $cache = new ArrayCache();
+        $cache->set('foo1', 'bar1');
+        $cache->set('foo2', 'bar2');
+        $cache->set('foo3', 'bar3');
+
+        $result1 = $cache->get('foo1');
+        $result2 = $cache->get('foo2');
+        $result3 = $cache->get('foo3');
+        $result4 = $cache->get('foo4');
+
+        $this->assertSame('bar1', $result1);
+        $this->assertSame('bar2', $result2);
+        $this->assertSame('bar3', $result3);
+        $this->assertNull($result4);
+
+    }
+
+    function testSetOverwritesPreviousValue() {
+
+        $cache = new ArrayCache();
+        $cache->set('foo1', 'bar1');
+        $cache->set('foo1', 'bar2');
+
+        $result = $cache->get('foo1');
+
+        $this->assertSame('bar2', $result);
+
+    }
+
+    function testSetOverwritesPreviousValueWhenCapacityReached() {
+
+        $cache = new ArrayCache(2);
+        $cache->set('foo1', 'bar1');
+        $cache->set('foo2', 'bar2');
+        $cache->set('foo1', 'bar3');
+
+        $result = $cache->get('foo1');
+
+        $this->assertSame('bar3', $result);
+
+    }
+
+    function testRemove() {
+
+        $cache = new ArrayCache();
+        $cache->set('foo', 'bar1');
+        $cache->set('foo', 'bar2');
+        $cache->remove('foo');
+
+        $result = $cache->get('foo');
+
+        $this->assertNull($result);
+
+    }
+
+    function testKeyExists() {
+
+        $cache = new ArrayCache();
+        $cache->set('foo1', 'bar');
+        $cache->set('foo2', 'bar');
+
+        $this->assertTrue($cache->keyExists('foo1'));
+        $this->assertTrue($cache->keyExists('foo2'));
+        $this->assertFalse($cache->keyExists('foo3'));
+    }
+
+    function testKeyExistsReturnsFalseAfterRemoval() {
+
+        $cache = new ArrayCache();
+        $cache->set('foo', 'bar');
+        $cache->remove('foo');
+
+        $this->assertFalse($cache->keyExists('foo'));
+    }
+
+    function testGetAllWhenEmpty() {
+
+        $cache = new ArrayCache();
+        $this->assertCount(0, iterator_to_array($cache->getAll()));
+
+    }
+
+    function testGetAllWithData() {
+
+        $cache = new ArrayCache();
+        $cache->set('foo1', 'old_bar');
+        $cache->set('foo1', 'new_bar');
+        $cache->set('foo2', 'bar_bar');
+
+        $result = iterator_to_array($cache->getAll());
+
+        $this->assertCount(2, $result);
+        $this->assertArrayHasKey('foo1', $result);
+        $this->assertArrayHasKey('foo2', $result);
+        $this->assertSame('new_bar', $result['foo1']);
+        $this->assertSame('bar_bar', $result['foo2']);
+
+    }
+
+    function testCacheSizeIsCapped() {
+
+        $cache = new ArrayCache(2);
+        $cache->set('key1', 'value1');
+        $cache->set('key2', 'value2');
+        $cache->set('key3', 'value3');
+
+        $this->assertCount(2, iterator_to_array($cache->getAll()));
+
+    }
+
+}


### PR DESCRIPTION
I'd like to propose one more memory usage optimization.

Issue this PR is solving is that cache size in `Sabre\DAV\Tree` (`$cache`) is currently *unlimited*.

When count of items grows to tens of thousands, size of `$cache` array grows linearly and can end up exhausting all the available memory.

For example in our case, when WebDAV collection listings contains 50000 items, cache uses around ~22MB (about 440B per item). When there is even more items in the collection, memory gets exhausted.

This PR adds `Cache` interface and simple implementation - `ArrayCache`, which has a cap on count of items in the cache -- it simply stops storing new items in the cache when cache capacity is reached.

Open questions:
- Q1: When the cache capacity is reached, would it be better to evict some of the existing items? would be "random" good enough eviction strategy?
- Q2: Is it fine to create new `Sabre\Common` namespace (just for the `Cache` and `ArrayCache` classes) or is there a better place for these classes?