### PR TITLE
Switched to using WildcardEmitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ ChangeLog
 
 * Now requires PHP 7.
 * Using `strict_types` in every php file.
+* #896: Using the [sabre/event][evnt] `WildcardEmitter`. This allows event
+  handlers to listen to events using a wildcard.
+* #896: Event listeners that in the past listened to `beforeMethod` or `method`
+  no longer get called. They must listen to `beforeMethod:*` and `method:*` now.
 
 
 3.2.1 (????-??-??)

--- a/lib/DAV/Auth/Plugin.php
+++ b/lib/DAV/Auth/Plugin.php
@@ -84,7 +84,7 @@ class Plugin extends ServerPlugin {
      */
     function initialize(Server $server) {
 
-        $server->on('beforeMethod', [$this, 'beforeMethod'], 10);
+        $server->on('beforeMethod:*', [$this, 'beforeMethod'], 10);
 
     }
 

--- a/lib/DAV/TemporaryFileFilterPlugin.php
+++ b/lib/DAV/TemporaryFileFilterPlugin.php
@@ -92,7 +92,7 @@ class TemporaryFileFilterPlugin extends ServerPlugin {
     function initialize(Server $server) {
 
         $this->server = $server;
-        $server->on('beforeMethod',    [$this, 'beforeMethod']);
+        $server->on('beforeMethod:*',   [$this, 'beforeMethod']);
         $server->on('beforeCreateFile', [$this, 'beforeCreateFile']);
 
     }

--- a/lib/DAVACL/Plugin.php
+++ b/lib/DAVACL/Plugin.php
@@ -816,7 +816,7 @@ class Plugin extends DAV\ServerPlugin {
 
         $this->server = $server;
         $server->on('propFind',            [$this, 'propFind'], 20);
-        $server->on('beforeMethod',        [$this, 'beforeMethod'], 20);
+        $server->on('beforeMethod:*',      [$this, 'beforeMethod'], 20);
         $server->on('beforeBind',          [$this, 'beforeBind'], 20);
         $server->on('beforeUnbind',        [$this, 'beforeUnbind'], 20);
         $server->on('propPatch',           [$this, 'propPatch']);

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -27,7 +27,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
-            $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()])
+            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()])
         );
 
     }
@@ -44,7 +44,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin($backend);
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
 
     }
 
@@ -61,7 +61,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin->autoRequireLogin = false;
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
-            $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()])
+            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()])
         );
         $this->assertEquals(1, count($plugin->getLoginFailedReasons()));
 
@@ -82,7 +82,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin->addBackend($backend2);
 
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
 
         $this->assertEquals('principals/admin', $plugin->getCurrentPrincipal());
 
@@ -98,7 +98,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin();
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
 
     }
     /**
@@ -113,7 +113,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin($backend);
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
 
     }
 
@@ -125,7 +125,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
         $this->assertEquals('principals/admin', $plugin->getCurrentPrincipal());
 
     }

--- a/tests/Sabre/DAV/ServerEventsTest.php
+++ b/tests/Sabre/DAV/ServerEventsTest.php
@@ -95,14 +95,14 @@ class ServerEventsTest extends AbstractServer {
     function testMethod() {
 
         $k = 1;
-        $this->server->on('method', function($request, $response) use (&$k) {
+        $this->server->on('method:*', function($request, $response) use (&$k) {
 
             $k += 1;
 
             return false;
 
         });
-        $this->server->on('method', function($request, $response) use (&$k) {
+        $this->server->on('method:*', function($request, $response) use (&$k) {
 
             $k += 2;
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -369,7 +369,7 @@ class ServerSimpleTest extends AbstractServer{
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = $httpRequest;
-        $this->server->on('beforeMethod', [$this, 'exceptionTrigger']);
+        $this->server->on('beforeMethod:*', [$this, 'exceptionTrigger']);
         $this->server->exec();
 
         $this->assertEquals([

--- a/tests/Sabre/DAV/TestPlugin.php
+++ b/tests/Sabre/DAV/TestPlugin.php
@@ -23,7 +23,7 @@ class TestPlugin extends ServerPlugin {
 
     function initialize(Server $server) {
 
-        $server->on('beforeMethod', [$this, 'beforeMethod']);
+        $server->on('beforeMethod:*', [$this, 'beforeMethod']);
 
     }
 

--- a/tests/Sabre/DAVACL/AllowAccessTest.php
+++ b/tests/Sabre/DAVACL/AllowAccessTest.php
@@ -40,7 +40,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('GET');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -49,7 +49,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('GET');
         $this->server->httpRequest->setUrl('/foo');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -58,7 +58,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('HEAD');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:HEAD', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -67,7 +67,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('OPTIONS');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:OPTIONS', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -76,7 +76,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('PUT');
         $this->server->httpRequest->setUrl('/testdir/file1.txt');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:PUT', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -85,7 +85,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('PROPPATCH');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:PROPPATCH', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -94,7 +94,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('COPY');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:COPY', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -103,7 +103,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('MOVE');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:MOVE', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 
@@ -112,7 +112,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('LOCK');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->assertTrue($this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]));
+        $this->assertTrue($this->server->emit('beforeMethod:LOCK', [$this->server->httpRequest, $this->server->httpResponse]));
 
     }
 

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -43,7 +43,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('GET');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -52,7 +52,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('GET');
         $this->server->httpRequest->setUrl('/foo');
 
-        $r = $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $r = $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
         $this->assertTrue($r);
 
     }
@@ -65,7 +65,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('HEAD');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -77,7 +77,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('OPTIONS');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -89,7 +89,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('PUT');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -101,7 +101,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('PROPPATCH');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -113,7 +113,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('COPY');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -125,7 +125,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('MOVE');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -137,7 +137,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('ACL');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 
@@ -149,7 +149,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         $this->server->httpRequest->setMethod('LOCK');
         $this->server->httpRequest->setUrl('/testdir');
 
-        $this->server->emit('beforeMethod', [$this->server->httpRequest, $this->server->httpResponse]);
+        $this->server->emit('beforeMethod:GET', [$this->server->httpRequest, $this->server->httpResponse]);
 
     }
 

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -76,7 +76,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $this->assertEquals(Xml\Property\Principal::UNAUTHENTICATED, $result[200]['{DAV:}current-user-principal']->getType());
 
         // This will force the login
-        $fakeServer->emit('beforeMethod', [$fakeServer->httpRequest, $fakeServer->httpResponse]);
+        $fakeServer->emit('beforeMethod:PROPFIND', [$fakeServer->httpRequest, $fakeServer->httpResponse]);
 
         $result = $fakeServer->getPropertiesForPath('', $requestedProperties);
         $result = $result[0];


### PR DESCRIPTION
This PR switches Sabre\DAV\Server to use the new wildcard emitter.

This solves a pretty weird issue regarding the order in which some event-callbacks are called. Before, you could hook into `beforeMethod:GET` or `method:GET` with a really low priority, but the flat `beforeMethod` and `method` events would still take precedence.

The wildcard emitter allows these types of events to share the same prioritization. The BC break is that event listeners that in the past listened to `beforeMethod` must now listen to `beforeMethod:*`.