### PR TITLE
Using the new, stricter sabre/http.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ ChangeLog
   handlers to listen to events using a wildcard.
 * #896: Event listeners that in the past listened to `beforeMethod` or `method`
   no longer get called. They must listen to `beforeMethod:*` and `method:*` now.
+* #322: Imap authentication backend. (@c0d3z3r0).
 
 
 3.2.1 (????-??-??)

--- a/lib/CalDAV/CalendarHome.php
+++ b/lib/CalDAV/CalendarHome.php
@@ -6,7 +6,7 @@ use Sabre\DAV;
 use Sabre\DAV\Exception\NotFound;
 use Sabre\DAV\MkCol;
 use Sabre\DAVACL;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * The CalendarHome represents a node that is usually in a users'
@@ -58,7 +58,7 @@ class CalendarHome implements DAV\IExtendedCollection, DAVACL\IACL {
      */
     function getName() {
 
-        list(, $name) = URLUtil::splitPath($this->principalInfo['uri']);
+        list(, $name) = Uri\split($this->principalInfo['uri']);
         return $name;
 
     }

--- a/lib/CalDAV/ICSExportPlugin.php
+++ b/lib/CalDAV/ICSExportPlugin.php
@@ -131,7 +131,7 @@ class ICSExportPlugin extends DAV\ServerPlugin {
             $componentType = $queryParams['componentType'];
         }
 
-        $format = \Sabre\HTTP\Util::Negotiate(
+        $format = \Sabre\HTTP\negotiateContentType(
             $request->getHeader('Accept'),
             [
                 'text/calendar',

--- a/lib/CalDAV/Plugin.php
+++ b/lib/CalDAV/Plugin.php
@@ -1020,7 +1020,7 @@ class Plugin extends DAV\ServerPlugin {
             return;
         }
 
-        $result = HTTP\Util::negotiate(
+        $result = HTTP\negotiateContentType(
             $request->getHeader('Accept'),
             ['text/calendar', 'application/calendar+json']
         );

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -9,8 +9,8 @@ use Sabre\DAVACL;
 use Sabre\HTTP;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
-use Sabre\VObject;
 use Sabre\Uri;
+use Sabre\VObject;
 
 /**
  * CardDAV plugin
@@ -804,7 +804,7 @@ class Plugin extends DAV\ServerPlugin {
      */
     protected function negotiateVCard($input, &$mimeType = null) {
 
-        $result = HTTP\Util::negotiate(
+        $result = HTTP\negotiateContentType(
             $input,
             [
                 // Most often used mime-type. Version 3

--- a/lib/CardDAV/Plugin.php
+++ b/lib/CardDAV/Plugin.php
@@ -10,6 +10,7 @@ use Sabre\HTTP;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
 use Sabre\VObject;
+use Sabre\Uri;
 
 /**
  * CardDAV plugin
@@ -218,7 +219,7 @@ class Plugin extends DAV\ServerPlugin {
      */
     protected function getAddressbookHomeForPrincipal($principal) {
 
-        list(, $principalId) = \Sabre\HTTP\URLUtil::splitPath($principal);
+        list(, $principalId) = Uri\split($principal);
         return self::ADDRESSBOOK_ROOT . '/' . $principalId;
 
     }

--- a/lib/DAV/Browser/GuessContentType.php
+++ b/lib/DAV/Browser/GuessContentType.php
@@ -5,7 +5,7 @@ namespace Sabre\DAV\Browser;
 use Sabre\DAV;
 use Sabre\DAV\Inode;
 use Sabre\DAV\PropFind;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * GuessContentType plugin
@@ -74,7 +74,7 @@ class GuessContentType extends DAV\ServerPlugin {
 
         $propFind->handle('{DAV:}getcontenttype', function() use ($propFind) {
 
-            list(, $fileName) = URLUtil::splitPath($propFind->getPath());
+            list(, $fileName) = Uri\split($propFind->getPath());
             return $this->getContentType($fileName);
 
         });

--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -4,9 +4,10 @@ namespace Sabre\DAV\Browser;
 
 use Sabre\DAV;
 use Sabre\DAV\MkCol;
+use Sabre\HTTP;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * Browser Plugin
@@ -184,7 +185,7 @@ class Plugin extends DAV\ServerPlugin {
                 case 'mkcol' :
                     if (isset($postVars['name']) && trim($postVars['name'])) {
                         // Using basename() because we won't allow slashes
-                        list(, $folderName) = URLUtil::splitPath(trim($postVars['name']));
+                        list(, $folderName) = Uri\split(trim($postVars['name']));
 
                         if (isset($postVars['resourceType'])) {
                             $resourceType = explode(',', $postVars['resourceType']);
@@ -222,12 +223,12 @@ class Plugin extends DAV\ServerPlugin {
                     if ($_FILES) $file = current($_FILES);
                     else break;
 
-                    list(, $newName) = URLUtil::splitPath(trim($file['name']));
+                    list(, $newName) = Uri\split(trim($file['name']));
                     if (isset($postVars['name']) && trim($postVars['name']))
                         $newName = trim($postVars['name']);
 
                     // Making sure we only have a 'basename' component
-                    list(, $newName) = URLUtil::splitPath($newName);
+                    list(, $newName) = Uri\split($newName);
 
                     if (is_uploaded_file($file['tmp_name'])) {
                         $this->server->createFile($uri . '/' . $newName, fopen($file['tmp_name'], 'r'));
@@ -283,8 +284,8 @@ class Plugin extends DAV\ServerPlugin {
             foreach ($subNodes as $subPath => $subProps) {
 
                 $subNode = $this->server->tree->getNodeForPath($subPath);
-                $fullPath = $this->server->getBaseUri() . URLUtil::encodePath($subPath);
-                list(, $displayPath) = URLUtil::splitPath($subPath);
+                $fullPath = $this->server->getBaseUri() . HTTP\encodePath($subPath);
+                list(, $displayPath) = Uri\split($subPath);
 
                 $subNodes[$subPath]['subNode'] = $subNode;
                 $subNodes[$subPath]['fullPath'] = $fullPath;
@@ -454,8 +455,8 @@ HTML;
 
         // If the path is empty, there's no parent.
         if ($path)  {
-            list($parentUri) = URLUtil::splitPath($path);
-            $fullPath = $this->server->getBaseUri() . URLUtil::encodePath($parentUri);
+            list($parentUri) = Uri\split($path);
+            $fullPath = $this->server->getBaseUri() . HTTP\encodePath($parentUri);
             $html .= '<a href="' . $fullPath . '" class="btn">⇤ Go to parent</a>';
         } else {
             $html .= '<span class="btn disabled">⇤ Go to parent</span>';

--- a/lib/DAV/FS/Node.php
+++ b/lib/DAV/FS/Node.php
@@ -3,7 +3,7 @@
 namespace Sabre\DAV\FS;
 
 use Sabre\DAV;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * Base node-class
@@ -43,7 +43,7 @@ abstract class Node implements DAV\INode {
      */
     function getName() {
 
-        list(, $name) = URLUtil::splitPath($this->path);
+        list(, $name) = Uri\split($this->path);
         return $name;
 
     }
@@ -56,8 +56,8 @@ abstract class Node implements DAV\INode {
      */
     function setName($name) {
 
-        list($parentPath, ) = URLUtil::splitPath($this->path);
-        list(, $newName) = URLUtil::splitPath($name);
+        list($parentPath, ) = Uri\split($this->path);
+        list(, $newName) = Uri\split($name);
 
         $newPath = $parentPath . '/' . $newName;
         rename($this->path, $newPath);

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -11,7 +11,6 @@ use Sabre\Event\WildcardEmitterTrait;
 use Sabre\HTTP;
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
-use Sabre\HTTP\URLUtil;
 use Sabre\Uri;
 
 /**
@@ -378,7 +377,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
             // Note that REQUEST_URI is percent encoded, while PATH_INFO is
             // not, Therefore they are only comparable if we first decode
             // REQUEST_INFO as well.
-            $decodedUri = URLUtil::decodePath($uri);
+            $decodedUri = HTTP\decodePath($uri);
 
             // A simple sanity check:
             if (substr($decodedUri, strlen($decodedUri) - strlen($pathInfo)) === $pathInfo) {
@@ -573,7 +572,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
 
         if (strpos($uri, $baseUri) === 0) {
 
-            return trim(URLUtil::decodePath(substr($uri, strlen($baseUri))), '/');
+            return trim(HTTP\decodePath(substr($uri, strlen($baseUri))), '/');
 
         // A special case, if the baseUri was accessed without a trailing
         // slash, we'll accept it as well.
@@ -736,7 +735,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
         // We need to throw a bad request exception, if the header was invalid
         else throw new Exception\BadRequest('The HTTP Overwrite header should be either T or F');
 
-        list($destinationDir) = URLUtil::splitPath($destination);
+        list($destinationDir) = Uri\split($destination);
 
         try {
             $destinationParent = $this->tree->getNodeForPath($destinationDir);
@@ -1073,7 +1072,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
      */
     function createFile($uri, $data, &$etag = null) {
 
-        list($dir, $name) = URLUtil::splitPath($uri);
+        list($dir, $name) = Uri\split($uri);
 
         if (!$this->emit('beforeBind', [$uri])) return false;
 
@@ -1154,7 +1153,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
      */
     function createCollection($uri, MkCol $mkCol) {
 
-        list($parentUri, $newName) = URLUtil::splitPath($uri);
+        list($parentUri, $newName) = Uri\split($uri);
 
         // Making sure the parent exists
         try {
@@ -1414,7 +1413,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
 
             // The If-Unmodified-Since will allow allow the request if the
             // entity has not changed since the specified date.
-            $date = HTTP\Util::parseHTTPDate($ifUnmodifiedSince);
+            $date = HTTP\parseDate($ifUnmodifiedSince);
 
             // We must only check the date if it's valid
             if ($date) {

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -863,7 +863,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
 
             // GetLastModified gets special cased
             } elseif ($properties[$property] instanceof Xml\Property\GetLastModified) {
-                $headers[$header] = HTTP\Util::toHTTPDate($properties[$property]->getTime());
+                $headers[$header] = HTTP\toDate($properties[$property]->getTime());
             }
 
         }
@@ -1391,7 +1391,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
             // header
             // Note that this header only has to be checked if there was no If-None-Match header
             // as per the HTTP spec.
-            $date = HTTP\Util::parseHTTPDate($ifModifiedSince);
+            $date = HTTP\parseDate($ifModifiedSince);
 
             if ($date) {
                 if (is_null($node)) {
@@ -1402,7 +1402,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
                     $lastMod = new \DateTime('@' . $lastMod);
                     if ($lastMod <= $date) {
                         $response->setStatus(304);
-                        $response->setHeader('Last-Modified', HTTP\Util::toHTTPDate($lastMod));
+                        $response->setHeader('Last-Modified', HTTP\toDate($lastMod));
                         return false;
                     }
                 }

--- a/lib/DAV/TemporaryFileFilterPlugin.php
+++ b/lib/DAV/TemporaryFileFilterPlugin.php
@@ -4,7 +4,7 @@ namespace Sabre\DAV;
 
 use Sabre\HTTP\RequestInterface;
 use Sabre\HTTP\ResponseInterface;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * Temporary File Filter Plugin
@@ -163,7 +163,7 @@ class TemporaryFileFilterPlugin extends ServerPlugin {
     protected function isTempFile($path) {
 
         // We're only interested in the basename.
-        list(, $tempPath) = URLUtil::splitPath($path);
+        list(, $tempPath) = Uri\split($path);
 
         foreach ($this->temporaryFilePatterns as $tempFile) {
 

--- a/lib/DAV/Tree.php
+++ b/lib/DAV/Tree.php
@@ -2,7 +2,7 @@
 
 namespace Sabre\DAV;
 
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * The tree object is responsible for basic tree operations.
@@ -61,7 +61,7 @@ class Tree {
         }
 
         // Attempting to fetch its parent
-        list($parentName, $baseName) = URLUtil::splitPath($path);
+        list($parentName, $baseName) = Uri\split($path);
 
         // If there was no parent, we must simply ask it from the root node.
         if ($parentName === "") {
@@ -98,7 +98,7 @@ class Tree {
             // The root always exists
             if ($path === '') return true;
 
-            list($parent, $base) = URLUtil::splitPath($path);
+            list($parent, $base) = Uri\split($path);
 
             $parentNode = $this->getNodeForPath($parent);
             if (!$parentNode instanceof ICollection) return false;
@@ -124,7 +124,7 @@ class Tree {
         $sourceNode = $this->getNodeForPath($sourcePath);
 
         // grab the dirname and basename components
-        list($destinationDir, $destinationName) = URLUtil::splitPath($destinationPath);
+        list($destinationDir, $destinationName) = Uri\split($destinationPath);
 
         $destinationParent = $this->getNodeForPath($destinationDir);
         $this->copyNode($sourceNode, $destinationParent, $destinationName);
@@ -142,8 +142,8 @@ class Tree {
      */
     function move($sourcePath, $destinationPath) {
 
-        list($sourceDir) = URLUtil::splitPath($sourcePath);
-        list($destinationDir, $destinationName) = URLUtil::splitPath($destinationPath);
+        list($sourceDir) = Uri\split($sourcePath);
+        list($destinationDir, $destinationName) = Uri\split($destinationPath);
 
         if ($sourceDir === $destinationDir) {
             // If this is a 'local' rename, it means we can just trigger a rename.
@@ -178,7 +178,7 @@ class Tree {
         $node = $this->getNodeForPath($path);
         $node->delete();
 
-        list($parent) = URLUtil::splitPath($path);
+        list($parent) = Uri\split($path);
         $this->markDirty($parent);
 
     }
@@ -255,7 +255,7 @@ class Tree {
         // Finding common parents
         $parents = [];
         foreach ($paths as $path) {
-            list($parent, $node) = URLUtil::splitPath($path);
+            list($parent, $node) = Uri\split($path);
             if (!isset($parents[$parent])) {
                 $parents[$parent] = [$node];
             } else {

--- a/lib/DAV/Xml/Property/GetLastModified.php
+++ b/lib/DAV/Xml/Property/GetLastModified.php
@@ -75,7 +75,7 @@ class GetLastModified implements Element {
     function xmlSerialize(Writer $writer) {
 
         $writer->write(
-            HTTP\Util::toHTTPDate($this->time)
+            HTTP\toDate($this->time)
         );
 
     }

--- a/lib/DAVACL/AbstractPrincipalCollection.php
+++ b/lib/DAVACL/AbstractPrincipalCollection.php
@@ -3,7 +3,7 @@
 namespace Sabre\DAVACL;
 
 use Sabre\DAV;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * Principals Collection
@@ -79,7 +79,7 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
      */
     function getName() {
 
-        list(, $name) = URLUtil::splitPath($this->principalPrefix);
+        list(, $name) = Uri\split($this->principalPrefix);
         return $name;
 
     }
@@ -149,7 +149,7 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
         $r = [];
 
         foreach ($result as $row) {
-            list(, $r[]) = URLUtil::splitPath($row);
+            list(, $r[]) = Uri\splitPath($row);
         }
 
         return $r;

--- a/lib/DAVACL/AbstractPrincipalCollection.php
+++ b/lib/DAVACL/AbstractPrincipalCollection.php
@@ -149,7 +149,7 @@ abstract class AbstractPrincipalCollection extends DAV\Collection implements IPr
         $r = [];
 
         foreach ($result as $row) {
-            list(, $r[]) = Uri\splitPath($row);
+            list(, $r[]) = Uri\split($row);
         }
 
         return $r;

--- a/lib/DAVACL/Principal.php
+++ b/lib/DAVACL/Principal.php
@@ -3,7 +3,7 @@
 namespace Sabre\DAVACL;
 
 use Sabre\DAV;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * Principal class
@@ -142,7 +142,7 @@ class Principal extends DAV\Node implements IPrincipal, DAV\IProperties, IACL {
     function getName() {
 
         $uri = $this->principalProperties['uri'];
-        list(, $name) = URLUtil::splitPath($uri);
+        list(, $name) = Uri\split($uri);
         return $name;
 
     }

--- a/lib/DAVACL/PrincipalBackend/PDO.php
+++ b/lib/DAVACL/PrincipalBackend/PDO.php
@@ -4,7 +4,7 @@ namespace Sabre\DAVACL\PrincipalBackend;
 
 use Sabre\DAV;
 use Sabre\DAV\MkCol;
-use Sabre\HTTP\URLUtil;
+use Sabre\Uri;
 
 /**
  * PDO principal backend
@@ -105,7 +105,7 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport {
         while ($row = $result->fetch(\PDO::FETCH_ASSOC)) {
 
             // Checking if the principal is in the prefix
-            list($rowPrefix) = URLUtil::splitPath($row['uri']);
+            list($rowPrefix) = Uri\split($row['uri']);
             if ($rowPrefix !== $prefixPath) continue;
 
             $principal = [
@@ -268,7 +268,7 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport {
         while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
 
             // Checking if the principal is in the prefix
-            list($rowPrefix) = URLUtil::splitPath($row['uri']);
+            list($rowPrefix) = Uri\split($row['uri']);
             if ($rowPrefix !== $prefixPath) continue;
 
             $principals[] = $row['uri'];
@@ -311,7 +311,7 @@ class PDO extends AbstractBackend implements CreatePrincipalSupport {
             
                 while ($row = $stmt->fetch(\PDO::FETCH_ASSOC)) {
                     // Checking if the principal is in the prefix
-                    list($rowPrefix) = URLUtil::splitPath($row['uri']);
+                    list($rowPrefix) = Uri\split($row['uri']);
                     if ($rowPrefix !== $principalPrefix) continue;
                     
                     $uri = $row['uri'];

--- a/tests/Sabre/CalDAV/FreeBusyReportTest.php
+++ b/tests/Sabre/CalDAV/FreeBusyReportTest.php
@@ -5,9 +5,6 @@ namespace Sabre\CalDAV;
 use Sabre\DAV;
 use Sabre\HTTP;
 
-require_once 'Sabre/CalDAV/Backend/Mock.php';
-require_once 'Sabre/HTTP/ResponseMock.php';
-
 class FreeBusyReportTest extends \PHPUnit_Framework_TestCase {
 
     /**
@@ -83,9 +80,7 @@ ics;
 
         $this->server = new DAV\Server([$calendar]);
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_URI' => '/calendar',
-        ]);
+        $request = new HTTP\Request('GET', '/calendar');
         $this->server->httpRequest = $request;
         $this->server->httpResponse = new HTTP\ResponseMock();
 

--- a/tests/Sabre/CalDAV/Notifications/PluginTest.php
+++ b/tests/Sabre/CalDAV/Notifications/PluginTest.php
@@ -57,7 +57,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $this->server->addPlugin($authPlugin);
 
         // This forces a login
-        $authPlugin->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $this->response = new HTTP\ResponseMock();
         $this->server->httpResponse = $this->response;

--- a/tests/Sabre/CalDAV/PluginTest.php
+++ b/tests/Sabre/CalDAV/PluginTest.php
@@ -89,11 +89,11 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $authBackend = new DAV\Auth\Backend\Mock();
         $authBackend->setPrincipal('principals/user1');
         $authPlugin = new DAV\Auth\Plugin($authBackend);
-        $authPlugin->beforeMethod(new \Sabre\HTTP\Request(), new \Sabre\HTTP\Response());
+        $authPlugin->beforeMethod(new \Sabre\HTTP\Request('GET', '/'), new \Sabre\HTTP\Response());
         $this->server->addPlugin($authPlugin);
 
         // This forces a login
-        $authPlugin->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $this->response = new HTTP\ResponseMock();
         $this->server->httpResponse = $this->response;

--- a/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
+++ b/tests/Sabre/CalDAV/Schedule/FreeBusyRequestTest.php
@@ -66,8 +66,8 @@ END:VCALENDAR',
             new CalDAV\CalendarRoot($principalBackend, $this->caldavBackend),
         ];
 
-        $this->request = HTTP\Sapi::createFromServerArray([
-            'CONTENT_TYPE' => 'text/calendar',
+        $this->request = new HTTP\Request('GET', '/', [
+            'Content-Type' => 'text/calendar',
         ]);
         $this->response = new HTTP\ResponseMock();
 
@@ -558,54 +558,5 @@ ICS;
         }
 
     }
-
-    /*
-    function testNoPrivilege() {
-
-        $this->markTestIncomplete('Currently there\'s no "no privilege" situation');
-
-        $this->server->httpRequest = HTTP\Sapi::createFromServerArray(array(
-            'CONTENT_TYPE' => 'text/calendar',
-            'REQUEST_METHOD' => 'POST',
-            'REQUEST_URI' => '/calendars/user1/outbox',
-        ));
-
-        $body = <<<ICS
-BEGIN:VCALENDAR
-METHOD:REQUEST
-BEGIN:VFREEBUSY
-ORGANIZER:mailto:user1.sabredav@sabredav.org
-ATTENDEE:mailto:user2.sabredav@sabredav.org
-DTSTART:20110101T080000Z
-DTEND:20110101T180000Z
-END:VFREEBUSY
-END:VCALENDAR
-ICS;
-
-        $this->server->httpRequest->setBody($body);
-
-        $this->assertFalse(
-            $this->plugin->httpPost($this->server->httpRequest, $this->response)
-        );
-
-        $this->assertEquals(200, $this->response->status);
-        $this->assertEquals([
-            'Content-Type' => 'application/xml',
-        ], $this->response->getHeaders());
-
-        $strings = [
-            '<d:href>mailto:user2.sabredav@sabredav.org</d:href>',
-            '<cal:request-status>3.7;No calendar-home-set property found</cal:request-status>',
-        ];
-
-        foreach($strings as $string) {
-            $this->assertTrue(
-                strpos($this->response->body, $string)!==false,
-                'The response body did not contain: ' . $string .'Full response: ' . $this->response->body
-            );
-        }
-
-
-    }*/
 
 }

--- a/tests/Sabre/CalDAV/Schedule/ScheduleDeliverTest.php
+++ b/tests/Sabre/CalDAV/Schedule/ScheduleDeliverTest.php
@@ -578,6 +578,7 @@ ICS;
 
     function deliver($oldObject, &$newObject, $disableScheduling = false) {
 
+        $this->server->httpRequest->setMethod('PUT');
         $this->server->httpRequest->setUrl($this->calendarObjectUri);
         if ($disableScheduling) {
             $this->server->httpRequest->setHeader('Schedule-Reply', 'F');

--- a/tests/Sabre/CalDAV/Schedule/ScheduleDeliverTest.php
+++ b/tests/Sabre/CalDAV/Schedule/ScheduleDeliverTest.php
@@ -3,6 +3,7 @@
 namespace Sabre\CalDAV\Schedule;
 
 use Sabre\HTTP\Request;
+use Sabre\Uri;
 use Sabre\VObject;
 
 class ScheduleDeliverTest extends \Sabre\DAVServerTest {
@@ -269,8 +270,7 @@ END:VCALENDAR
 ICS;
 
 
-        $this->server->httpRequest->setMethod('MOVE');
-        $this->deliver($oldObject, $newObject);
+        $this->deliver($oldObject, $newObject, false, 'MOVE');
         $this->assertItemsInInbox('user2', 0);
 
     }
@@ -576,9 +576,9 @@ ICS;
 
     protected $calendarObjectUri;
 
-    function deliver($oldObject, &$newObject, $disableScheduling = false) {
+    function deliver($oldObject, &$newObject, $disableScheduling = false, $method = 'PUT') {
 
-        $this->server->httpRequest->setMethod('PUT');
+        $this->server->httpRequest->setMethod($method);
         $this->server->httpRequest->setUrl($this->calendarObjectUri);
         if ($disableScheduling) {
             $this->server->httpRequest->setHeader('Schedule-Reply', 'F');
@@ -644,7 +644,7 @@ ICS;
      */
     function putPath($path, $data) {
 
-        list($parent, $base) = \Sabre\HTTP\UrlUtil::splitPath($path);
+        list($parent, $base) = Uri\split($path);
         $parentNode = $this->server->tree->getNodeForPath($parent);
 
         /*

--- a/tests/Sabre/CalDAV/SharingPluginTest.php
+++ b/tests/Sabre/CalDAV/SharingPluginTest.php
@@ -72,7 +72,7 @@ class SharingPluginTest extends \Sabre\DAVServerTest {
     function testBeforeGetShareableCalendar() {
 
         // Forcing the server to authenticate:
-        $this->authPlugin->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $this->authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
         $props = $this->server->getProperties('calendars/user1/cal1', [
             '{' . Plugin::NS_CALENDARSERVER . '}invite',
             '{' . Plugin::NS_CALENDARSERVER . '}allowed-sharing-modes',

--- a/tests/Sabre/CardDAV/PluginTest.php
+++ b/tests/Sabre/CardDAV/PluginTest.php
@@ -91,7 +91,7 @@ class PluginTest extends AbstractPluginTest {
 
     function testGetTransform() {
 
-        $request = new \Sabre\HTTP\Request('GET', '/addressbooks/user1/book1/card1', ['Accept: application/vcard+json']);
+        $request = new \Sabre\HTTP\Request('GET', '/addressbooks/user1/book1/card1', ['Accept' => 'application/vcard+json']);
         $response = new \Sabre\HTTP\ResponseMock();
         $this->server->invokeMethod($request, $response);
 

--- a/tests/Sabre/CardDAV/SogoStripContentTypeTest.php
+++ b/tests/Sabre/CardDAV/SogoStripContentTypeTest.php
@@ -31,8 +31,8 @@ class SogoStripContentTypeTest extends \Sabre\DAVServerTest {
     }
     function testStrip() {
 
-        $this->server->httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:10.0.2) Gecko/20120216 Thunderbird/10.0.2 Lightning/1.2.1',
+        $this->server->httpRequest = new HTTP\Request('GET', '/', [
+            'User-Agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.6; rv:10.0.2) Gecko/20120216 Thunderbird/10.0.2 Lightning/1.2.1',
         ]);
         $result = $this->server->getProperties('addressbooks/user1/book1/card1.vcf', ['{DAV:}getcontenttype']);
         $this->assertEquals([

--- a/tests/Sabre/DAV/Auth/Backend/AbstractBasicTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractBasicTest.php
@@ -8,7 +8,7 @@ class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
 
     function testCheckNoHeaders() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractBasicMock();
@@ -22,8 +22,10 @@ class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
     function testCheckUnknownUser() {
 
         $request = HTTP\Sapi::createFromServerArray([
-            'PHP_AUTH_USER' => 'username',
-            'PHP_AUTH_PW'   => 'wrongpassword',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/',
+            'PHP_AUTH_USER'  => 'username',
+            'PHP_AUTH_PW'    => 'wrongpassword',
         ]);
         $response = new HTTP\Response();
 
@@ -38,8 +40,10 @@ class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
     function testCheckSuccess() {
 
         $request = HTTP\Sapi::createFromServerArray([
-            'PHP_AUTH_USER' => 'username',
-            'PHP_AUTH_PW'   => 'password',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/',
+            'PHP_AUTH_USER'  => 'username',
+            'PHP_AUTH_PW'    => 'password',
         ]);
         $response = new HTTP\Response();
 
@@ -53,7 +57,7 @@ class AbstractBasicTest extends \PHPUnit_Framework_TestCase {
 
     function testRequireAuth() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractBasicMock();

--- a/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractBearerTest.php
@@ -4,13 +4,11 @@ namespace Sabre\DAV\Auth\Backend;
 
 use Sabre\HTTP;
 
-require_once 'Sabre/HTTP/ResponseMock.php';
-
 class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 
     function testCheckNoHeaders() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractBearerMock();
@@ -23,8 +21,8 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 
     function testCheckInvalidToken() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'HTTP_AUTHORIZATION' => 'Bearer foo',
+        $request = new HTTP\Request('GET', '/', [
+            'Authorization' => 'Bearer foo',
         ]);
         $response = new HTTP\Response();
 
@@ -38,8 +36,8 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 
     function testCheckSuccess() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'HTTP_AUTHORIZATION' => 'Bearer valid',
+        $request = new HTTP\Request('GET', '/', [
+            'Authorization' => 'Bearer valid',
         ]);
         $response = new HTTP\Response();
 
@@ -53,7 +51,7 @@ class AbstractBearerTest extends \PHPUnit_Framework_TestCase {
 
     function testRequireAuth() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractBearerMock();

--- a/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
@@ -40,6 +40,8 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
         $header = 'username=array, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_URI' => '/',
+            'REQUEST_METHOD' => 'GET',
             'PHP_AUTH_DIGEST' => $header,
         ]);
 

--- a/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/AbstractDigestTest.php
@@ -8,7 +8,7 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
     function testCheckNoHeaders() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractDigestMock();
@@ -22,6 +22,8 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
         $header = 'username=null, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD'  => 'GET',
+            'REQUEST_URI'     => '/',
             'PHP_AUTH_DIGEST' => $header,
         ]);
         $response = new HTTP\Response();
@@ -40,8 +42,8 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
         $header = 'username=array, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_URI' => '/',
-            'REQUEST_METHOD' => 'GET',
+            'REQUEST_METHOD'  => 'GET',
+            'REQUEST_URI'     => '/',
             'PHP_AUTH_DIGEST' => $header,
         ]);
 
@@ -56,6 +58,8 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
         $header = 'username=false, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD'  => 'GET',
+            'REQUEST_URI'     => '/',
             'PHP_AUTH_DIGEST' => $header,
         ]);
 
@@ -72,8 +76,9 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
         $header = 'username=user, realm=myRealm, nonce=12345, uri=/, response=HASH, opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
-            'PHP_AUTH_DIGEST' => $header,
             'REQUEST_METHOD'  => 'PUT',
+            'REQUEST_URI'     => '/',
+            'PHP_AUTH_DIGEST' => $header,
         ]);
 
         $response = new HTTP\Response();
@@ -91,8 +96,8 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
         $header = 'username=user, realm=myRealm, nonce=12345, uri=/, response=' . $digestHash . ', opaque=1, qop=auth, nc=1, cnonce=1';
         $request = HTTP\Sapi::createFromServerArray([
             'REQUEST_METHOD'  => 'GET',
-            'PHP_AUTH_DIGEST' => $header,
             'REQUEST_URI'     => '/',
+            'PHP_AUTH_DIGEST' => $header,
         ]);
 
         $response = new HTTP\Response();
@@ -107,7 +112,7 @@ class AbstractDigestTest extends \PHPUnit_Framework_TestCase {
 
     function testRequireAuth() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new AbstractDigestMock();

--- a/tests/Sabre/DAV/Auth/Backend/ApacheTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/ApacheTest.php
@@ -15,7 +15,7 @@ class ApacheTest extends \PHPUnit_Framework_TestCase {
 
     function testNoHeader() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
         $backend = new Apache();
 
@@ -28,7 +28,9 @@ class ApacheTest extends \PHPUnit_Framework_TestCase {
     function testRemoteUser() {
 
         $request = HTTP\Sapi::createFromServerArray([
-            'REMOTE_USER' => 'username',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/',
+            'REMOTE_USER'    => 'username',
         ]);
         $response = new HTTP\Response();
         $backend = new Apache();
@@ -43,6 +45,8 @@ class ApacheTest extends \PHPUnit_Framework_TestCase {
     function testRedirectRemoteUser() {
 
         $request = HTTP\Sapi::createFromServerArray([
+            'REQUEST_METHOD'       => 'GET',
+            'REQUEST_URI'          => '/',
             'REDIRECT_REMOTE_USER' => 'username',
         ]);
         $response = new HTTP\Response();
@@ -57,7 +61,7 @@ class ApacheTest extends \PHPUnit_Framework_TestCase {
 
     function testRequireAuth() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/');
         $response = new HTTP\Response();
 
         $backend = new Apache();

--- a/tests/Sabre/DAV/Auth/Backend/BasicCallBackTest.php
+++ b/tests/Sabre/DAV/Auth/Backend/BasicCallBackTest.php
@@ -2,8 +2,7 @@
 
 namespace Sabre\DAV\Auth\Backend;
 
-use Sabre\HTTP\Response;
-use Sabre\HTTP\Sapi;
+use Sabre\HTTP;
 
 class BasicCallBackTest extends \PHPUnit_Framework_TestCase {
 
@@ -19,10 +18,10 @@ class BasicCallBackTest extends \PHPUnit_Framework_TestCase {
 
         $backend = new BasicCallBack($callBack);
 
-        $request = Sapi::createFromServerArray([
-            'HTTP_AUTHORIZATION' => 'Basic ' . base64_encode('foo:bar'),
+        $request = new HTTP\Request('GET', '/', [
+            'Authorization' => 'Basic ' . base64_encode('foo:bar'),
         ]);
-        $response = new Response();
+        $response = new HTTP\Response();
 
         $this->assertEquals(
             [true, 'principals/foo'],

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -44,7 +44,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin($backend);
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
 
     }
 
@@ -82,7 +82,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin->addBackend($backend2);
 
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
 
         $this->assertEquals('principals/admin', $plugin->getCurrentPrincipal());
 
@@ -98,7 +98,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin();
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
 
     }
     /**
@@ -113,7 +113,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
 
         $plugin = new Plugin($backend);
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
 
     }
 
@@ -125,7 +125,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $fakeServer = new DAV\Server(new DAV\SimpleCollection('bla'));
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
-        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()]);
+        $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()]);
         $this->assertEquals('principals/admin', $plugin->getCurrentPrincipal());
 
     }

--- a/tests/Sabre/DAV/Auth/PluginTest.php
+++ b/tests/Sabre/DAV/Auth/PluginTest.php
@@ -27,7 +27,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin = new Plugin(new Backend\Mock());
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
-            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()])
+            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()])
         );
 
     }
@@ -61,7 +61,7 @@ class PluginTest extends \PHPUnit_Framework_TestCase {
         $plugin->autoRequireLogin = false;
         $fakeServer->addPlugin($plugin);
         $this->assertTrue(
-            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request(), new HTTP\Response()])
+            $fakeServer->emit('beforeMethod:GET', [new HTTP\Request('GET', '/'), new HTTP\Response()])
         );
         $this->assertEquals(1, count($plugin->getLoginFailedReasons()));
 

--- a/tests/Sabre/DAV/ClientMock.php
+++ b/tests/Sabre/DAV/ClientMock.php
@@ -3,6 +3,7 @@
 namespace Sabre\DAV;
 
 use Sabre\HTTP\RequestInterface;
+use Sabre\HTTP\ResponseInterface;
 
 class ClientMock extends Client {
 
@@ -24,7 +25,7 @@ class ClientMock extends Client {
 
     }
 
-    function doRequest(RequestInterface $request) {
+    function doRequest(RequestInterface $request) : ResponseInterface {
 
         $this->request = $request;
         return $this->response;

--- a/tests/Sabre/DAV/FSExt/ServerTest.php
+++ b/tests/Sabre/DAV/FSExt/ServerTest.php
@@ -27,7 +27,7 @@ class ServerTest extends DAV\AbstractServer{
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
-            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($filename)))],
+            'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($filename)))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
             $this->response->getHeaders()
@@ -49,7 +49,7 @@ class ServerTest extends DAV\AbstractServer{
             'X-Sabre-Version' => [DAV\Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
-            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
+            'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($this->tempDir . '/test.txt')))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
             $this->response->getHeaders()

--- a/tests/Sabre/DAV/GetIfConditionsTest.php
+++ b/tests/Sabre/DAV/GetIfConditionsTest.php
@@ -11,7 +11,7 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testNoConditions() {
 
-        $request = new HTTP\Request();
+        $request = new HTTP\Request('GET', '/foo');
 
         $conditions = $this->server->getIfConditions($request);
         $this->assertEquals([], $conditions);
@@ -45,12 +45,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testNotLockToken() {
 
-        $serverVars = [
-            'HTTP_IF'     => '(Not <opaquelocktoken:token1>)',
-            'REQUEST_URI' => '/bla'
-        ];
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '(Not <opaquelocktoken:token1>)',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -74,11 +72,9 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testLockTokenUrl() {
 
-        $serverVars = [
-            'HTTP_IF' => '<http://www.example.com/> (<opaquelocktoken:token1>)',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '<http://www.example.com/> (<opaquelocktoken:token1>)',
+        ]);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -102,12 +98,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2LockTokens() {
 
-        $serverVars = [
-            'HTTP_IF'     => '(<opaquelocktoken:token1>) (Not <opaquelocktoken:token2>)',
-            'REQUEST_URI' => '/bla',
-        ];
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '(<opaquelocktoken:token1>) (Not <opaquelocktoken:token2>)',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -136,11 +130,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2UriLockTokens() {
 
-        $serverVars = [
-            'HTTP_IF' => '<http://www.example.org/node1> (<opaquelocktoken:token1>) <http://www.example.org/node2> (Not <opaquelocktoken:token2>)',
-        ];
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '<http://www.example.org/node1> (<opaquelocktoken:token1>) <http://www.example.org/node2> (Not <opaquelocktoken:token2>)',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -174,11 +167,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2UriMultiLockTokens() {
 
-        $serverVars = [
-            'HTTP_IF' => '<http://www.example.org/node1> (<opaquelocktoken:token1>) (<opaquelocktoken:token2>) <http://www.example.org/node2> (Not <opaquelocktoken:token3>)',
-        ];
+        $request = new HTTP\Request('GET', '/bla', [
+            'If' => '<http://www.example.org/node1> (<opaquelocktoken:token1>) (<opaquelocktoken:token2>) <http://www.example.org/node2> (Not <opaquelocktoken:token3>)',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -217,12 +209,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testEtag() {
 
-        $serverVars = [
-            'HTTP_IF'     => '(["etag1"])',
-            'REQUEST_URI' => '/foo',
-        ];
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '(["etag1"])',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -245,11 +235,10 @@ class GetIfConditionsTest extends AbstractServer {
 
     function test2Etags() {
 
-        $serverVars = [
-            'HTTP_IF' => '<http://www.example.org/> (["etag1"]) (["etag2"])',
-        ];
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '<http://www.example.org/> (["etag1"]) (["etag2"])',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [
@@ -277,13 +266,12 @@ class GetIfConditionsTest extends AbstractServer {
 
     function testComplexIf() {
 
-        $serverVars = [
-            'HTTP_IF' => '<http://www.example.org/node1> (<opaquelocktoken:token1> ["etag1"]) ' .
-                         '(Not <opaquelocktoken:token2>) (["etag2"]) <http://www.example.org/node2> ' .
-                         '(<opaquelocktoken:token3>) (Not <opaquelocktoken:token4>) (["etag3"])',
-        ];
+        $request = new HTTP\Request('GET', '/foo', [
+            'If' => '<http://www.example.org/node1> (<opaquelocktoken:token1> ["etag1"]) ' .
+                    '(Not <opaquelocktoken:token2>) (["etag2"]) <http://www.example.org/node2> ' .
+                    '(<opaquelocktoken:token3>) (Not <opaquelocktoken:token4>) (["etag3"])',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $conditions = $this->server->getIfConditions($request);
 
         $compare = [

--- a/tests/Sabre/DAV/HTTPPreferParsingTest.php
+++ b/tests/Sabre/DAV/HTTPPreferParsingTest.php
@@ -6,83 +6,82 @@ use Sabre\HTTP;
 
 class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
 
-    function testParseSimple() {
+    function assertParseResult($input, $expected) {
 
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_PREFER' => 'return-asynch',
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'Prefer' => $input,
         ]);
 
         $server = new Server();
         $server->httpRequest = $httpRequest;
 
-        $this->assertEquals([
-            'respond-async' => true,
-            'return'        => null,
-            'handling'      => null,
-            'wait'          => null,
-        ], $server->getHTTPPrefer());
+        $this->assertEquals(
+            $expected,
+            $server->getHTTPPrefer()
+        );
+
+    }
+
+    function testParseSimple() {
+
+        $this->assertParseResult(
+            'return-asynch',
+            [
+                'respond-async' => true,
+                'return'        => null,
+                'handling'      => null,
+                'wait'          => null,
+            ]
+        );
 
     }
 
     function testParseValue() {
 
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_PREFER' => 'wait=10',
-        ]);
-
-        $server = new Server();
-        $server->httpRequest = $httpRequest;
-
-        $this->assertEquals([
-            'respond-async' => false,
-            'return'        => null,
-            'handling'      => null,
-            'wait'          => '10',
-        ], $server->getHTTPPrefer());
+        $this->assertParseResult(
+            'wait=10',
+            [
+                'respond-async' => false,
+                'return'        => null,
+                'handling'      => null,
+                'wait'          => '10',
+            ]
+        );
 
     }
 
     function testParseMultiple() {
 
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_PREFER' => 'return-minimal, strict,lenient',
-        ]);
-
-        $server = new Server();
-        $server->httpRequest = $httpRequest;
-
-        $this->assertEquals([
-            'respond-async' => false,
-            'return'        => 'minimal',
-            'handling'      => 'lenient',
-            'wait'          => null,
-        ], $server->getHTTPPrefer());
+        $this->assertParseResult(
+            'return-minimal, strict,lenient',
+            [
+                'respond-async' => false,
+                'return'        => 'minimal',
+                'handling'      => 'lenient',
+                'wait'          => null,
+            ]
+        );
 
     }
 
     function testParseWeirdValue() {
 
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_PREFER' => 'BOOOH',
-        ]);
-
-        $server = new Server();
-        $server->httpRequest = $httpRequest;
-
-        $this->assertEquals([
-            'respond-async' => false,
-            'return'        => null,
-            'handling'      => null,
-            'wait'          => null,
-            'boooh'         => true,
-        ], $server->getHTTPPrefer());
-
+        $this->assertParseResult(
+            'BOOOH',
+            [
+                'respond-async' => false,
+                'return'        => null,
+                'handling'      => null,
+                'wait'          => null,
+                'boooh'         => true,
+            ]
+        );
     }
 
     function testBrief() {
 
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_BRIEF' => 't',
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'Brief' => 't',
         ]);
 
         $server = new Server();
@@ -104,10 +103,8 @@ class HTTPPreferParsingTest extends \Sabre\DAVServerTest {
      */
     function testpropfindMinimal() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_METHOD' => 'PROPFIND',
-            'REQUEST_URI'    => '/',
-            'HTTP_PREFER'    => 'return-minimal',
+        $request = new HTTP\Request('PROPFIND', '/', [
+            'Prefer' => 'return-minimal',
         ]);
         $request->setBody(<<<BLA
 <?xml version="1.0"?>

--- a/tests/Sabre/DAV/Issue33Test.php
+++ b/tests/Sabre/DAV/Issue33Test.php
@@ -22,13 +22,10 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
         $server = new Server($root);
         $server->setBaseUri('/webdav/');
 
-        $serverVars = [
-            'REQUEST_URI'      => '/webdav/bar',
-            'HTTP_DESTINATION' => 'http://dev2.tribalos.com/webdav/%C3%A0fo%C3%B3',
-            'HTTP_OVERWRITE'   => 'F',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('GET', '/webdav/bar', [
+            'Destination' => 'http://dev2.tribalos.com/webdav/%C3%A0fo%C3%B3',
+            'Overwrite'   => 'F',
+        ]);
 
         $server->httpRequest = $request;
 
@@ -70,15 +67,11 @@ class Issue33Test extends \PHPUnit_Framework_TestCase {
      */
     function testEverything() {
 
-        // Request object
-        $serverVars = [
-            'REQUEST_METHOD'   => 'MOVE',
-            'REQUEST_URI'      => '/webdav/bar',
-            'HTTP_DESTINATION' => 'http://dev2.tribalos.com/webdav/%C3%A0fo%C3%B3',
-            'HTTP_OVERWRITE'   => 'F',
-        ];
+        $request = new HTTP\Request('MOVE', '/webdav/bar', [
+            'Destination' => 'http://dev2.tribalos.com/webdav/%C3%A0fo%C3%B3',
+            'Overwrite'   => 'F',
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $request->setBody('');
 
         $response = new HTTP\ResponseMock();

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -990,9 +990,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testGetTimeoutHeaderInvalid() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'HTTP_TIMEOUT' => 'yourmom',
-        ]);
+        $request = new HTTP\Request('GET' ,'/', ['Timeout' => 'yourmom']);
 
         $this->server->httpRequest = $request;
         $this->locksPlugin->getTimeoutHeader();

--- a/tests/Sabre/DAV/Locks/PluginTest.php
+++ b/tests/Sabre/DAV/Locks/PluginTest.php
@@ -395,10 +395,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockRetainOwner() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ]);
+        $request = new HTTP\Request('LOCK', '/test.txt');
         $this->server->httpRequest = $request;
 
         $request->setBody('<?xml version="1.0"?>
@@ -423,12 +420,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockPutBadToken() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/test.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -446,13 +438,9 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'PUT',
-            'HTTP_IF'        => '(<opaquelocktoken:token1>)',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('PUT', '/test.txt', [
+            'If' => '(<opaquelocktoken:token1>)',
+        ]);
         $request->setBody('newbody');
         $this->server->httpRequest = $request;
         $this->server->exec();
@@ -470,12 +458,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockDeleteParent() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -493,12 +476,7 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir',
-            'REQUEST_METHOD' => 'DELETE',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('DELETE', '/dir');
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -511,12 +489,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockDeleteSucceed() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -534,13 +507,9 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child.txt',
-            'REQUEST_METHOD' => 'DELETE',
-            'HTTP_IF'        => '(' . $this->response->getHeader('Lock-Token') . ')',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('DELETE', '/dir/child.txt', [
+            'If' => '(' . $this->response->getHeader('Lock-Token') . ')',
+        ]);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -554,12 +523,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockCopyLockSource() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -577,13 +541,10 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'      => '/dir/child.txt',
-            'REQUEST_METHOD'   => 'COPY',
-            'HTTP_DESTINATION' => '/dir/child2.txt',
-        ];
+        $request = new HTTP\Request('COPY', '/dir/child.txt', [
+            'Destination' => '/dir/child2.txt'
+        ]);
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -596,12 +557,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockCopyLockDestination() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child2.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child2.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -619,13 +575,9 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(201, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'      => '/dir/child.txt',
-            'REQUEST_METHOD'   => 'COPY',
-            'HTTP_DESTINATION' => '/dir/child2.txt',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('COPY', '/dir/child.txt', [
+            'Destination' => '/dir/child2.txt',
+        ]);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -639,12 +591,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockMoveLockSourceLocked() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -662,13 +609,9 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'      => '/dir/child.txt',
-            'REQUEST_METHOD'   => 'MOVE',
-            'HTTP_DESTINATION' => '/dir/child2.txt',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('MOVE', '/dir/child.txt', [
+            'Destination' => '/dir/child2.txt',
+        ]);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -682,12 +625,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockMoveLockSourceSucceed() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -705,14 +643,11 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'      => '/dir/child.txt',
-            'REQUEST_METHOD'   => 'MOVE',
-            'HTTP_DESTINATION' => '/dir/child2.txt',
-            'HTTP_IF'          => '(' . $this->response->getHeader('Lock-Token') . ')',
-        ];
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('MOVE', '/dir/child.txt', [
+            'Destination' => '/dir/child2.txt',
+            'If'          => '(' . $this->response->getHeader('Lock-Token') . ')',
+        ]);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -725,12 +660,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockMoveLockDestination() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir/child2.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir/child2.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -748,13 +678,9 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(201, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'      => '/dir/child.txt',
-            'REQUEST_METHOD'   => 'MOVE',
-            'HTTP_DESTINATION' => '/dir/child2.txt',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('MOVE', '/dir/child.txt', [
+            'Destination' => '/dir/child2.txt',
+        ]);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -767,13 +693,9 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockMoveLockParent() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir',
-            'REQUEST_METHOD' => 'LOCK',
-            'HTTP_DEPTH'     => 'infinite',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/dir', [
+            'Depth' => 'infinite',
+        ]);
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -791,14 +713,10 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'      => '/dir/child.txt',
-            'REQUEST_METHOD'   => 'MOVE',
-            'HTTP_DESTINATION' => '/dir/child2.txt',
-            'HTTP_IF'          => '</dir> (' . $this->response->getHeader('Lock-Token') . ')',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('MOVE', '/dir/child.txt', [
+            'Destination' => '/dir/child2.txt',
+            'If'          => '</dir> (' . $this->response->getHeader('Lock-Token') . ')',
+        ]);
         $this->server->httpRequest = $request;
         $this->server->exec();
 
@@ -812,12 +730,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testLockPutGoodToken() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'LOCK',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('LOCK', '/test.txt');
         $request->setBody('<?xml version="1.0"?>
 <D:lockinfo xmlns:D="DAV:">
     <D:lockscope><D:exclusive/></D:lockscope>
@@ -835,13 +748,10 @@ class PluginTest extends DAV\AbstractServer {
 
         $this->assertEquals(200, $this->response->status);
 
-        $serverVars = [
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'PUT',
-            'HTTP_IF'        => '(' . $this->response->getHeader('Lock-Token') . ')',
-        ];
+        $request = new HTTP\Request('PUT', '/test.txt', [
+            'If' => '(' . $this->response->getHeader('Lock-Token') . ')',
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        ]);
         $request->setBody('newbody');
         $this->server->httpRequest = $request;
         $this->server->exec();
@@ -894,13 +804,9 @@ class PluginTest extends DAV\AbstractServer {
 
     function testPutWithIncorrectETag() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'PUT',
-            'HTTP_IF'        => '(["etag1"])',
-        ];
-
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('PUT', '/test.txt', [
+            'If' => '(["etag1"])',
+        ]);
         $request->setBody('newbody');
         $this->server->httpRequest = $request;
         $this->server->exec();
@@ -923,14 +829,12 @@ class PluginTest extends DAV\AbstractServer {
             filesize($filename) .
             filemtime($filename)
         );
-        $serverVars = [
-            'REQUEST_URI'    => '/test.txt',
-            'REQUEST_METHOD' => 'PUT',
-            'HTTP_IF'        => '(["' . $etag . '"])',
-        ];
 
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('PUT', '/test.txt', [
+            'If' => '(["' . $etag . '"])',
+        ]);
         $request->setBody('newbody');
+
         $this->server->httpRequest = $request;
         $this->server->exec();
         $this->assertEquals(204, $this->response->status, 'Incorrect status received. Full response body:' . $this->response->body);
@@ -939,12 +843,9 @@ class PluginTest extends DAV\AbstractServer {
 
     function testDeleteWithETagOnCollection() {
 
-        $serverVars = [
-            'REQUEST_URI'    => '/dir',
-            'REQUEST_METHOD' => 'DELETE',
-            'HTTP_IF'        => '(["etag1"])',
-        ];
-        $request = HTTP\Sapi::createFromServerArray($serverVars);
+        $request = new HTTP\Request('DELETE', '/dir', [
+            'If' => '(["etag1"])',
+        ]);
 
         $this->server->httpRequest = $request;
         $this->server->exec();
@@ -954,8 +855,8 @@ class PluginTest extends DAV\AbstractServer {
 
     function testGetTimeoutHeader() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'HTTP_TIMEOUT' => 'second-100',
+        $request = new HTTP\Request('LOCK', '/foo/bar', [
+            'Timeout' => 'second-100',
         ]);
 
         $this->server->httpRequest = $request;
@@ -965,10 +866,9 @@ class PluginTest extends DAV\AbstractServer {
 
     function testGetTimeoutHeaderTwoItems() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'HTTP_TIMEOUT' => 'second-5, infinite',
+        $request = new HTTP\Request('LOCK', '/foo/bar', [
+            'Timeout' => 'second-5, infinite',
         ]);
-
         $this->server->httpRequest = $request;
         $this->assertEquals(5, $this->locksPlugin->getTimeoutHeader());
 
@@ -976,10 +876,9 @@ class PluginTest extends DAV\AbstractServer {
 
     function testGetTimeoutHeaderInfinite() {
 
-        $request = HTTP\Sapi::createFromServerArray([
-            'HTTP_TIMEOUT' => 'infinite, second-5',
+        $request = new HTTP\Request('LOCK', '/foo/bar', [
+            'Timeout' => 'infinite, second-5',
         ]);
-
         $this->server->httpRequest = $request;
         $this->assertEquals(LockInfo::TIMEOUT_INFINITE, $this->locksPlugin->getTimeoutHeader());
 
@@ -990,7 +889,7 @@ class PluginTest extends DAV\AbstractServer {
      */
     function testGetTimeoutHeaderInvalid() {
 
-        $request = new HTTP\Request('GET' ,'/', ['Timeout' => 'yourmom']);
+        $request = new HTTP\Request('GET', '/', ['Timeout' => 'yourmom']);
 
         $this->server->httpRequest = $request;
         $this->locksPlugin->getTimeoutHeader();

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -206,9 +206,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_MODIFIED_SINCE' => 'Sun, 06 Nov 1994 08:49:37 GMT',
-            'REQUEST_URI'            => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Modified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
         $server->httpResponse = new HTTP\ResponseMock();
         $this->assertFalse($server->checkPreconditions($httpRequest, $server->httpResponse));
@@ -227,9 +226,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_MODIFIED_SINCE' => 'Tue, 06 Nov 1984 08:49:37 GMT',
-            'REQUEST_URI'            => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Modified-Since' => 'Tue, 06 Nov 1984 08:49:37 GMT',
         ]);
 
         $httpResponse = new HTTP\ResponseMock();
@@ -243,9 +241,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_MODIFIED_SINCE' => 'Your mother',
-            'REQUEST_URI'            => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Modified-Since' => 'Your mother',
         ]);
         $httpResponse = new HTTP\ResponseMock();
 
@@ -260,9 +257,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_MODIFIED_SINCE' => 'Sun, 06 Nov 1994 08:49:37 EST',
-            'REQUEST_URI'            => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Unmodified-Since' => 'Sun, 06 Nov 1994 08:49:37 EST',
         ]);
         $httpResponse = new HTTP\ResponseMock();
         $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
@@ -276,9 +272,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_UNMODIFIED_SINCE' => 'Sun, 06 Nov 1994 08:49:37 GMT',
-            'REQUEST_URI'              => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Unmodified-Since' => 'Sun, 06 Nov 1994 08:49:37 GMT',
         ]);
         $httpResponse = new HTTP\Response();
         $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));
@@ -307,9 +302,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_UNMODIFIED_SINCE' => 'Sun, 06 Nov 1984 08:49:37 CET',
-            'REQUEST_URI'              => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Unmodified-Since' => 'Sun, 06 Nov 1984 08:49:37 CET',
         ]);
         $httpResponse = new HTTP\ResponseMock();
         $this->assertTrue($server->checkPreconditions($httpRequest, $httpResponse));

--- a/tests/Sabre/DAV/ServerPreconditionTest.php
+++ b/tests/Sabre/DAV/ServerPreconditionTest.php
@@ -293,9 +293,8 @@ class ServerPreconditionsTest extends \PHPUnit_Framework_TestCase {
 
         $root = new SimpleCollection('root', [new ServerPreconditionsNode()]);
         $server = new Server($root);
-        $httpRequest = HTTP\Sapi::createFromServerArray([
-            'HTTP_IF_UNMODIFIED_SINCE' => 'Tue, 06 Nov 1984 08:49:37 GMT',
-            'REQUEST_URI'              => '/foo'
+        $httpRequest = new HTTP\Request('GET', '/foo', [
+            'If-Unmodified-Since' => 'Tue, 06 Nov 1984 08:49:37 GMT',
         ]);
         $httpResponse = new HTTP\ResponseMock();
         $server->checkPreconditions($httpRequest, $httpResponse);

--- a/tests/Sabre/DAV/ServerRangeTest.php
+++ b/tests/Sabre/DAV/ServerRangeTest.php
@@ -26,7 +26,7 @@ class ServerRangeTest extends \Sabre\DAVServerTest {
         parent::setUp();
         $this->server->createFile('files/test.txt', 'Test contents');
 
-        $this->lastModified = HTTP\Util::toHTTPDate(
+        $this->lastModified = HTTP\toDate(
             new DateTime('@' . $this->server->tree->getNodeForPath('files/test.txt')->getLastModified())
         );
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -120,7 +120,7 @@ class ServerSimpleTest extends AbstractServer{
             'X-Sabre-Version' => [Version::VERSION],
             'Content-Type'    => ['application/octet-stream'],
             'Content-Length'  => [13],
-            'Last-Modified'   => [HTTP\Util::toHTTPDate(new \DateTime('@' . filemtime($filename)))],
+            'Last-Modified'   => [HTTP\toDate(new \DateTime('@' . filemtime($filename)))],
             'ETag'            => ['"' . sha1(fileinode($filename) . filesize($filename) . filemtime($filename)) . '"'],
             ],
             $this->response->getHeaders()
@@ -229,8 +229,9 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUri() {
 
         $serverVars = [
-            'REQUEST_URI' => '/index.php/root',
-            'PATH_INFO'   => '/root',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/index.php/root',
+            'PATH_INFO'      => '/root',
         ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
@@ -247,8 +248,9 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriPercentEncoding() {
 
         $serverVars = [
-            'REQUEST_URI' => '/index.php/dir/path2/path%20with%20spaces',
-            'PATH_INFO'   => '/dir/path2/path with spaces',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/index.php/dir/path2/path%20with%20spaces',
+            'PATH_INFO'      => '/dir/path2/path with spaces',
         ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
@@ -282,8 +284,9 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUri2() {
 
         $serverVars = [
-            'REQUEST_URI' => '/index.php/root/',
-            'PATH_INFO'   => '/root/',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/index.php/root/',
+            'PATH_INFO'      => '/root/',
         ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
@@ -297,7 +300,8 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriNoPathInfo() {
 
         $serverVars = [
-            'REQUEST_URI' => '/index.php/root',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/index.php/root',
         ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
@@ -310,11 +314,7 @@ class ServerSimpleTest extends AbstractServer{
 
     function testGuessBaseUriNoPathInfo2() {
 
-        $serverVars = [
-            'REQUEST_URI' => '/a/b/c/test.php',
-        ];
-
-        $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
+        $httpRequest = new HTTP\Request('GET', '/a/b/c/test.php');
         $server = new Server();
         $server->httpRequest = $httpRequest;
 
@@ -329,8 +329,9 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriQueryString() {
 
         $serverVars = [
-            'REQUEST_URI' => '/index.php/root?query_string=blabla',
-            'PATH_INFO'   => '/root',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/index.php/root?query_string=blabla',
+            'PATH_INFO'      => '/root',
         ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);
@@ -348,8 +349,9 @@ class ServerSimpleTest extends AbstractServer{
     function testGuessBaseUriBadConfig() {
 
         $serverVars = [
-            'REQUEST_URI' => '/index.php/root/heyyy',
-            'PATH_INFO'   => '/root',
+            'REQUEST_METHOD' => 'GET',
+            'REQUEST_URI'    => '/index.php/root/heyyy',
+            'PATH_INFO'      => '/root',
         ];
 
         $httpRequest = HTTP\Sapi::createFromServerArray($serverVars);

--- a/tests/Sabre/DAVACL/ACLMethodTest.php
+++ b/tests/Sabre/DAVACL/ACLMethodTest.php
@@ -32,7 +32,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request();
+        $server->httpRequest = new HTTP\Request('GET', '/');
         $body = '<?xml version="1.0"?>
 <d:acl xmlns:d="DAV:">
 </d:acl>';
@@ -51,7 +51,7 @@ class ACLMethodTest extends \PHPUnit_Framework_TestCase {
         ];
         $acl = new Plugin();
         $server = new DAV\Server($tree);
-        $server->httpRequest = new HTTP\Request();
+        $server->httpRequest = new HTTP\Request('GET', '/');
         $server->httpRequest->setUrl('/test');
 
         $body = '<?xml version="1.0"?>

--- a/tests/Sabre/DAVACL/AllowAccessTest.php
+++ b/tests/Sabre/DAVACL/AllowAccessTest.php
@@ -27,7 +27,7 @@ class AllowAccessTest extends \PHPUnit_Framework_TestCase {
         );
         // Login
         $this->server->getPlugin('auth')->beforeMethod(
-            new \Sabre\HTTP\Request(),
+            new \Sabre\HTTP\Request('GET', '/'),
             new \Sabre\HTTP\Response()
         );
         $aclPlugin = new Plugin();

--- a/tests/Sabre/DAVACL/BlockAccessTest.php
+++ b/tests/Sabre/DAVACL/BlockAccessTest.php
@@ -28,7 +28,7 @@ class BlockAccessTest extends \PHPUnit_Framework_TestCase {
         );
         // Login
         $this->server->getPlugin('auth')->beforeMethod(
-            new \Sabre\HTTP\Request(),
+            new \Sabre\HTTP\Request('GET', '/'),
             new \Sabre\HTTP\Response()
         );
         $this->server->addPlugin($this->plugin);

--- a/tests/Sabre/DAVACL/PluginPropertiesTest.php
+++ b/tests/Sabre/DAVACL/PluginPropertiesTest.php
@@ -185,7 +185,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($authPlugin);
 
         // Force login
-        $authPlugin->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $requestedProperties = [
             '{DAV:}acl',
@@ -224,7 +224,7 @@ class PluginPropertiesTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($authPlugin);
 
         // Force login
-        $authPlugin->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $authPlugin->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $requestedProperties = [
             '{DAV:}acl-restrictions',

--- a/tests/Sabre/DAVACL/SimplePluginTest.php
+++ b/tests/Sabre/DAVACL/SimplePluginTest.php
@@ -153,7 +153,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($auth);
 
         //forcing login
-        $auth->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $auth->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $this->assertEquals(['principals/admin'], $acl->getCurrentUserPrincipals());
 
@@ -181,7 +181,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($auth);
 
         //forcing login
-        $auth->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $auth->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $expected = [
             'principals/admin',
@@ -260,7 +260,7 @@ class SimplePluginTest extends \PHPUnit_Framework_TestCase {
         $server->addPlugin($auth);
 
         //forcing login
-        $auth->beforeMethod(new HTTP\Request(), new HTTP\Response());
+        $auth->beforeMethod(new HTTP\Request('GET', '/'), new HTTP\Response());
 
         $expected = [
             '{DAV:}write',

--- a/tests/Sabre/DAVServerTest.php
+++ b/tests/Sabre/DAVServerTest.php
@@ -227,7 +227,7 @@ abstract class DAVServerTest extends \PHPUnit_Framework_TestCase {
         $this->server->addPlugin($this->authPlugin);
 
         // This will trigger the actual login procedure
-        $this->authPlugin->beforeMethod(new Request(), new Response());
+        $this->authPlugin->beforeMethod(new Request('GET', '/'), new Response());
     }
 
     /**


### PR DESCRIPTION
This new build will make it easier to spot subtle errors. Highlights:

* Removed deprecated API's
* A HTTP request object can now no longer be created unless it has both a method and a path (basically the absolute minimum for any http request to be valid).