### PR TITLE
exec() is start().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ ChangeLog
 
 * SimpleCollection can now take arrays and strings as argument for super
   simple tree creation.
+* Added `Sabre\DAV\Server::start()`. This replaces `::exec()`. `::exec()`
+  is now deprecated, but we're keeping it around for a year or two to make
+  the transition easier.
 
 
 3.2.1 (????-??-??)

--- a/examples/addressbookserver.php
+++ b/examples/addressbookserver.php
@@ -54,4 +54,4 @@ $server->addPlugin(new Sabre\DAVACL\Plugin());
 $server->addPlugin(new Sabre\DAV\Sync\Plugin());
 
 // And off we go!
-$server->exec();
+$server->start();

--- a/examples/calendarserver.php
+++ b/examples/calendarserver.php
@@ -77,4 +77,4 @@ $browser = new Sabre\DAV\Browser\Plugin();
 $server->addPlugin($browser);
 
 // And off we go!
-$server->exec();
+$server->start();

--- a/examples/fileserver.php
+++ b/examples/fileserver.php
@@ -53,4 +53,4 @@ $tempFF = new \Sabre\DAV\TemporaryFileFilterPlugin($tmpDir);
 $server->addPlugin($tempFF);
 
 // And off we go!
-$server->exec();
+$server->start();

--- a/examples/groupwareserver.php
+++ b/examples/groupwareserver.php
@@ -98,4 +98,4 @@ $server->addPlugin(new \Sabre\CardDAV\Plugin());
 $server->addPlugin(new \Sabre\CardDAV\VCFExportPlugin());
 
 // And off we go!
-$server->exec();
+$server->start();

--- a/examples/minimal.php
+++ b/examples/minimal.php
@@ -17,4 +17,4 @@ $server->addPlugin(
     new Sabre\DAV\Browser\Plugin()
 );
 
-$server->exec();
+$server->start();

--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -229,7 +229,7 @@ class Server extends EventEmitter implements LoggerAwareInterface {
      *
      * @return void
      */
-    function exec() {
+    function start() {
 
         try {
 
@@ -312,6 +312,18 @@ class Server extends EventEmitter implements LoggerAwareInterface {
             $this->sapi->sendResponse($this->httpResponse);
 
         }
+
+    }
+
+    /**
+     * Alias of start().
+     *
+     * @deprecated
+     * @return void
+     */
+    function exec() {
+
+        $this->start();
 
     }
 


### PR DESCRIPTION
Doing something I've been wanting to do for a few years now, replace
exec() with start(). I plan on waiting 1 or 2 major versions to get rid
of exec() though as this is a bit silly.