### PR TITLE
Allow asset delivery from within phar files.

### DIFF
--- a/lib/DAV/Browser/Plugin.php
+++ b/lib/DAV/Browser/Plugin.php
@@ -561,10 +561,20 @@ HTML;
         if (strpos($path, '/../') !== false || strrchr($path, '/') === '/..') {
             throw new DAV\Exception\NotFound('Path does not exist, or escaping from the base path was detected');
         }
-        $realPath = realpath($path);
-        if ($realPath && strpos($realPath, realpath($assetDir)) === 0 && file_exists($path)) {
-            return $path;
+
+        $scriptFilename = realpath($_SERVER['SCRIPT_FILENAME']);
+        if (strtolower(substr($scriptFilename, -5)) == '.phar') {
+            $pharPrefix = 'phar://' . $scriptFilename;
+            if (strpos($assetDir, $pharPrefix) === 0)  {
+                return $path;
+            }
+        } else {
+            $realPath = realpath($path);
+            if ($realPath && strpos($realPath, realpath($assetDir)) === 0 && file_exists($path)) {
+                return $path;
+            }
         }
+
         throw new DAV\Exception\NotFound('Path does not exist, or escaping from the base path was detected');
     }
 


### PR DESCRIPTION
I created a minimal server that provides the Cal|CardDAV functionality for me. I want to deploy it though a single phar file. For me that has the advantage that composer is not needed to be installed and that I can easily update it (to a tested version).

I can see that the check might not be optimal and I'm very open to suggestions to make it better. 