### PR TITLE
Schedule plugin now creates/updates calendar objects using built-in Server methods.

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -552,8 +552,7 @@ class Plugin extends ServerPlugin {
         // We may need to look a bit deeper into this later. Supporting ACL
         // here would be nice.
         if ($isNewNode) {
-            $calendar = $this->server->tree->getNodeForPath($calendarPath);
-            $calendar->createFile($newFileName, $newObject->serialize());
+            $this->server->createFile($calendarPath . $newFileName, $newObject->serialize());
         } else {
             // If the message was a reply, we may have to inform other
             // attendees of this attendees status. Therefore we're shooting off
@@ -566,7 +565,8 @@ class Plugin extends ServerPlugin {
                     [$iTipMessage->sender]
                 );
             }
-            $objectNode->put($newObject->serialize());
+
+            $this->server->updateFile($objectPath, $newObject->serialize());
         }
         $iTipMessage->scheduleStatus = '1.2;Message delivered locally';
 


### PR DESCRIPTION
This fixes #933 

I'm willing to write unit tests for this, but before doing so I would like to know if this change is valid or not. It works in our context but maybe I'm wrong at doing so, and there's another option.
Also can you point me to where and how unit tests should be written for this?

Thanks,