### PR TITLE
dont disable xdebug manually anymore in travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ php:
   - 7.0
   - 7.1
 
-
 env:
   matrix:
     - LOWEST_DEPS="" TEST_DEPS=""
@@ -20,8 +19,6 @@ before_script:
   - mysql -e 'create database sabredav_test'
   - psql -c "create database sabredav_test" -U postgres
   - psql -c "create user sabredav with PASSWORD 'sabredav';GRANT ALL PRIVILEGES ON DATABASE sabredav_test TO sabredav" -U postgres
-  - phpenv config-rm xdebug.ini; true
-  #  - composer self-update
   - composer update --prefer-dist $LOWEST_DEPS
 
 # Required for postgres 9.5


### PR DESCRIPTION
travis updates composer within the build to 1.3.x which contains a native workaround for xdebug problems.