### PR TITLE
Don't throw a Notice in calculateUri when passing an empty uri

### DIFF
--- a/lib/DAV/Server.php
+++ b/lib/DAV/Server.php
@@ -565,7 +565,7 @@ class Server implements LoggerAwareInterface, EmitterInterface {
      */
     function calculateUri($uri) {
 
-        if ($uri[0] != '/' && strpos($uri, '://')) {
+        if ($uri != '' && $uri[0] != '/' && strpos($uri, '://')) {
 
             $uri = parse_url($uri, PHP_URL_PATH);
 

--- a/tests/Sabre/DAV/ServerSimpleTest.php
+++ b/tests/Sabre/DAV/ServerSimpleTest.php
@@ -163,6 +163,16 @@ class ServerSimpleTest extends AbstractServer{
 
         $this->assertEquals('', $this->server->calculateUri('/root'));
 
+        $this->server->setBaseUri('/');
+
+        foreach ($uris as $uri) {
+
+            $this->assertEquals('root/somepath', $this->server->calculateUri($uri));
+
+        }
+
+        $this->assertEquals('', $this->server->calculateUri(''));
+
     }
 
     function testCalculateUriSpecialChars() {


### PR DESCRIPTION
When a dav server listening on the root of a domain receives a request to the root of that domain, the request $uri will be an empty string.

Besides the one Notice that was thrown the rest of the implementation works correctly in that case ($uri = '', $baseUri = '/')