### PR TITLE
Return empty array as requested by PHPDoc ...

### DIFF
--- a/lib/CalDAV/Schedule/Plugin.php
+++ b/lib/CalDAV/Schedule/Plugin.php
@@ -707,7 +707,7 @@ class Plugin extends ServerPlugin {
 
         // If we can't find this information, we'll stop processing
         if (!isset($properties[$CUAS])) {
-            return;
+            return [];
         }
 
         $addresses = $properties[$CUAS]->getHrefs();


### PR DESCRIPTION
... followup functions like processICalendarChange expect an array as well. Returning null here will result in a type error

Argument 3 passed to Sabre\\CalDAV\\Schedule\\Plugin::processICalendarChange() must be of the type array, null given