### PR TITLE
Add reader->contextUri initialisation to parse function

### DIFF
--- a/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetTest.php
+++ b/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetTest.php
@@ -15,11 +15,13 @@ class AddressBookMultiGetTest extends XmlTest {
         /* lines look a bit odd but this triggers an XML parsing bug */
         $xml = <<<XML
 <?xml version='1.0' encoding='UTF-8' ?>
-<CARD:addressbook-multiget xmlns="DAV:" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
-  <prop>
-    <getcontenttype />
-    <getetag />
-    <CARD:address-data content-type="text/vcard" version="4.0" /></prop><href>/foo.vcf</href>
+<CARD:addressbook-multiget xmlns:d="DAV:" xmlns:CARD="urn:ietf:params:xml:ns:carddav">
+  <d:prop>
+    <d:getcontenttype />
+    <d:getetag />
+    <CARD:address-data content-type="text/vcard" version="4.0" />
+  </d:prop>
+  <d:href>/foo.vcf</d:href>
 </CARD:addressbook-multiget>
 XML;
 

--- a/tests/Sabre/DAV/Xml/XmlTest.php
+++ b/tests/Sabre/DAV/Xml/XmlTest.php
@@ -26,6 +26,7 @@ abstract class XmlTest extends \PHPUnit_Framework_TestCase {
     function parse($xml, array $elementMap = []) {
 
         $reader = new Reader();
+        $reader->contextUri = $this->contextUri;
         $reader->elementMap = array_merge($this->elementMap, $elementMap);
         $reader->xml($xml);
         return $reader->parse();


### PR DESCRIPTION
**Actual behavior :**
The build is actually failing because of the `testDeserialize` of the `/tests/Sabre/CardDAV/Xml/Request/AddressBookMultiGetTest.php`.

This is because the contextUri of the reader is not initialized at his creation.

https://travis-ci.org/fruux/sabre-dav/jobs/221757014

**Expecting behavior**
The tests should pass. :)